### PR TITLE
Handle joint selectors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@carbonplan/maps",
-  "version": "1.0.0-alpha.15",
+  "version": "1.0.0-alpha.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@carbonplan/maps",
-      "version": "1.0.0-alpha.15",
+      "version": "1.0.0-alpha.17",
       "license": "MIT",
       "dependencies": {
         "@turf/turf": "^6.5.0",
@@ -16,7 +16,7 @@
         "ndarray": "^1.0.19",
         "regl": "^2.1.0",
         "xhr-request": "^1.1.0",
-        "zarr-js": "^2.0.0"
+        "zarr-js": "^2.1.1"
       },
       "devDependencies": {
         "microbundle": "^0.13.0",
@@ -7340,9 +7340,9 @@
       }
     },
     "node_modules/zarr-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-2.0.0.tgz",
-      "integrity": "sha512-f7/z84ZGlz97pACoCE0fVMRojJaenD61H5VLuEPmsBi7aqV9eaMQQl2zz426WQMumBjr3x/6twO0ZUyJ9fFW2g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-2.1.1.tgz",
+      "integrity": "sha512-IrlK/XtLJAPbDRCnhBs2R360O8A4pUbKcyBkS/D30Y8qqIMH/wNA7Nf0o33cdjZ8Tth2HxEWuKcxlOc19M8XWQ==",
       "dependencies": {
         "async": "^2.6.2",
         "cartesian-product": "^2.1.2",
@@ -12861,9 +12861,9 @@
       "dev": true
     },
     "zarr-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-2.0.0.tgz",
-      "integrity": "sha512-f7/z84ZGlz97pACoCE0fVMRojJaenD61H5VLuEPmsBi7aqV9eaMQQl2zz426WQMumBjr3x/6twO0ZUyJ9fFW2g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-2.1.1.tgz",
+      "integrity": "sha512-IrlK/XtLJAPbDRCnhBs2R360O8A4pUbKcyBkS/D30Y8qqIMH/wNA7Nf0o33cdjZ8Tth2HxEWuKcxlOc19M8XWQ==",
       "requires": {
         "async": "^2.6.2",
         "cartesian-product": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ndarray": "^1.0.19",
     "regl": "^2.1.0",
     "xhr-request": "^1.1.0",
-    "zarr-js": "^2.0.1"
+    "zarr-js": "^2.1.1"
   },
   "peerDependencies": {
     "react": "^16.14.0 || ^17.0.2",

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -60,6 +60,7 @@ export const createTiles = (regl, opts) => {
       )
     }
 
+    this.dimensions = dimensions
     this.ndim = dimensions.length
     this.bands = getBands(variable, selector)
 
@@ -79,10 +80,10 @@ export const createTiles = (regl, opts) => {
 
     if (mode === 'texture') {
       primitive = 'triangles'
-      const emptyTexture = ndarray(new Float32Array(Array(1).fill(fillValue)), [
-        1,
-        1,
-      ])
+      const emptyTexture = ndarray(
+        new Float32Array(Array(1).fill(fillValue)),
+        [1, 1]
+      )
       initialize = () => regl.texture(emptyTexture)
       this.bands.forEach((k) => (uniforms[k] = regl.prop(k)))
     }
@@ -141,11 +142,16 @@ export const createTiles = (regl, opts) => {
             const coordinates = Array.from(chunk.data)
             this.coordinates = {}
             this.coordinates[key] = coordinates
-            this.accessors = getAccessors(this.bands, selector, coordinates)
+            this.accessors = getAccessors(
+              this.dimensions,
+              this.bands,
+              selector,
+              this.coordinates
+            )
             resolve(true)
           })
         } else {
-          this.accessors = getAccessors(this.bands, selector)
+          this.accessors = getAccessors(this.dimensions, this.bands, selector)
           resolve(true)
         }
       })

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -137,11 +137,19 @@ export const createTiles = (regl, opts) => {
         })
 
         if (Object.keys(selector).length > 0) {
-          const key = Object.keys(selector)[0]
-          loaders['0/' + key]([0], (err, chunk) => {
-            const coordinates = Array.from(chunk.data)
-            this.coordinates = {}
-            this.coordinates[key] = coordinates
+          this.coordinates = {}
+          Promise.all(
+            Object.keys(selector).map(
+              (key) =>
+                new Promise((innerResolve) => {
+                  loaders['0/' + key]([0], (err, chunk) => {
+                    const coordinates = Array.from(chunk.data)
+                    this.coordinates[key] = coordinates
+                    innerResolve()
+                  })
+                })
+            )
+          ).then(() => {
             this.accessors = getAccessors(
               this.dimensions,
               this.bands,

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -80,10 +80,10 @@ export const createTiles = (regl, opts) => {
 
     if (mode === 'texture') {
       primitive = 'triangles'
-      const emptyTexture = ndarray(
-        new Float32Array(Array(1).fill(fillValue)),
-        [1, 1]
-      )
+      const emptyTexture = ndarray(new Float32Array(Array(1).fill(fillValue)), [
+        1,
+        1,
+      ])
       initialize = () => regl.texture(emptyTexture)
       this.bands.forEach((k) => (uniforms[k] = regl.prop(k)))
     }

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -19,7 +19,8 @@ import {
   getBands,
   getAccessors,
   getSelectorHash,
-  updateResultForPosition,
+  getValuesToSet,
+  setObjectValues,
 } from './utils'
 
 export const createTiles = (regl, opts) => {
@@ -363,13 +364,17 @@ export const createTiles = (regl, opts) => {
               lat.push(pointCoords[1])
 
               if (this.ndim > 2) {
-                updateResultForPosition(
-                  results,
+                const valuesToSet = getValuesToSet(
                   data,
+                  i,
+                  j,
                   this.dimensions,
-                  this.coordinates,
-                  { x: i, y: j }
+                  this.coordinates
                 )
+
+                valuesToSet.forEach(({ keys, value }) => {
+                  setObjectValues(results, keys, value)
+                })
               } else {
                 results.push(data.get(j, i))
               }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import { combine, point, rhumbBearing, rhumbDestination } from '@turf/turf'
+import { point, rhumbBearing, rhumbDestination } from '@turf/turf'
 
 const d2r = Math.PI / 180
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -348,7 +348,7 @@ export const updateResultForPosition = (
   }
 }
 
-const getPicker = (dimensions, selector, bandInfo, coordinates) => {
+const getPicker = (dimensions, selector, band, coordinates) => {
   return (data, s) => {
     const indexes = dimensions
       .map((d) => (['x', 'y'].includes(d) ? null : d))
@@ -358,7 +358,7 @@ const getPicker = (dimensions, selector, bandInfo, coordinates) => {
         } else {
           let value
           if (Array.isArray(selector[d])) {
-            value = bandInfo[d]
+            value = band
           } else {
             value = s[d]
           }
@@ -379,10 +379,8 @@ export const getAccessors = (
   if (Object.keys(selector).length === 0) {
     return { [bands[0]]: (d) => d }
   } else {
-    const bandInformation = getBandInformation(selector)
     const result = bands.reduce((accessors, band) => {
-      const info = bandInformation[band]
-      accessors[band] = getPicker(dimensions, selector, info, coordinates)
+      accessors[band] = getPicker(dimensions, selector, band, coordinates)
       return accessors
     }, {})
     return result

--- a/src/utils.js
+++ b/src/utils.js
@@ -289,6 +289,13 @@ export const getBands = (variable, selector = {}) => {
   }
 }
 
+/**
+ * Mutates a given object by adding `value` to array at nested location specified by `keys`
+ * @param {obj} Object of any structure
+ * @param {Array<string>} keys describing nested location where value should be set
+ * @param {any} value to be added to array at location specified by keys
+ * @returns reference to updated obj
+ */
 export const setObjectValues = (obj, keys, value) => {
   let ref = obj
   keys.forEach((key, i) => {
@@ -308,6 +315,15 @@ export const setObjectValues = (obj, keys, value) => {
   return obj
 }
 
+/**
+ * Returns all `value`s and identifying `keys` from iterating over the dimensions of `data` at specified x,y location
+ * @param {data} ndarray
+ * @param {x} number x coordinate at which to lookup values
+ * @param {y} number y coordinate at which to lookup values
+ * @param {Array<string>} dimensions to iterate over
+ * @param {{[dimension]: Array<any>}} coordinate names to use for `keys`
+ * @returns Array of containing `keys: Array<string>` and `value: any` (value of `data` corresponding to `keys`)
+ */
 export const getValuesToSet = (data, x, y, dimensions, coordinates) => {
   let keys = [[]]
   let indexes = [[]]

--- a/src/utils.js
+++ b/src/utils.js
@@ -298,7 +298,6 @@ const getBandInformation = (selector) => {
 export const getBands = (variable, selector = {}) => {
   const bandInfo = getBandInformation(selector)
   const bandNames = Object.keys(bandInfo)
-  console.log('using new getBands', bandInfo, bandNames, selector, variable)
 
   if (Object.keys(bandNames).length > 0) {
     return bandNames

--- a/src/utils.js
+++ b/src/utils.js
@@ -257,44 +257,34 @@ export const getPyramidMetadata = (metadata) => {
   return { levels, maxZoom, tileSize }
 }
 
-const getBandInformation = (selector) => {
-  const combinedBands = Object.keys(selector)
+export const getBands = (variable, selector = {}) => {
+  const selectorBands = Object.keys(selector)
+    // Only create bands for keys with multiple values
     .filter((key) => Array.isArray(selector[key]))
-    .reduce((bandMapping, key) => {
-      const value = selector[key]
-      let currentBands
-      if (typeof value[0] === 'string') {
-        currentBands = value
-      } else {
-        currentBands = value.map((d) => key + '_' + d)
+    .reduce((bands, key) => {
+      let selectorValues = selector[key]
+      // Identify integer values by corresponding selector key
+      if (typeof selectorValues[0] === 'number') {
+        selectorValues = selectorValues.map((d) => key + '_' + d)
       }
 
-      const bands = Object.keys(bandMapping)
-      const updatedBands = {}
-      currentBands.forEach((currentKey, i) => {
+      const updatedBands = []
+      selectorValues.forEach((value, i) => {
         if (bands.length > 0) {
-          bands.forEach((band) => {
-            const bandKey = `${band}_${currentKey}`
-            updatedBands[bandKey] = { ...bands[band], [currentKey]: value[i] }
-          })
+          bands.forEach((band) => updatedBands.push(`${band}_${value}`))
         } else {
-          updatedBands[currentKey] = { [currentKey]: value[i] }
+          updatedBands.push(value)
         }
       })
 
       return updatedBands
-    }, {})
+    }, [])
 
-  return combinedBands
-}
-
-export const getBands = (variable, selector = {}) => {
-  const bandInfo = getBandInformation(selector)
-  const bandNames = Object.keys(bandInfo)
-
-  if (Object.keys(bandNames).length > 0) {
-    return bandNames
+  if (Object.keys(selectorBands).length > 0) {
+    // Use specific bands for selector when applicable
+    return selectorBands
   } else {
+    // Otherwise, just use variable as single band name
     return [variable]
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -299,6 +299,55 @@ export const getBands = (variable, selector = {}) => {
   }
 }
 
+const setter = (obj, keys, value) => {
+  let ref = obj
+  keys.forEach((key, i) => {
+    if (i === keys.length - 1) {
+      if (!ref[key]) {
+        ref[key] = []
+      }
+    } else {
+      if (!ref[key]) {
+        ref[key] = {}
+      }
+    }
+    ref = ref[key]
+  })
+
+  ref.push(value)
+  return obj
+}
+
+export const updateResultForPosition = (
+  result,
+  data,
+  dimensions,
+  coordinates,
+  fixed = {}
+) => {
+  const indexes = dimensions.map((dimension, i) => {
+    const values = coordinates[dimension]
+    const index = fixed[dimension]
+    if (typeof index === 'number') {
+      return { index, key: values && values[index] }
+    } else {
+      values.forEach((v, j) => {
+        updateResultForPosition(result, data, dimensions, coordinates, {
+          ...fixed,
+          [dimension]: j,
+        })
+      })
+    }
+  })
+
+  // set value in result
+  if (indexes.every(Boolean)) {
+    const keys = indexes.map(({ key }) => key).filter(Boolean)
+    const value = data.get(...indexes.map(({ index }) => index))
+    setter(result, keys, value)
+  }
+}
+
 const getPicker = (dimensions, selector, bandInfo, coordinates) => {
   return (data, s) => {
     const indexes = dimensions

--- a/src/utils.js
+++ b/src/utils.js
@@ -257,13 +257,6 @@ export const getPyramidMetadata = (metadata) => {
   return { levels, maxZoom, tileSize }
 }
 
-// {{month: 0, bands: [‘temperature’, ‘precipitation’]}}
-// => temperature, precipitation
-// {{month: [0, 1], bands: [‘temperature’, ‘precipitation’]}}
-// => temperature_0, precipitation_0, temperature_1, precipitation_1
-// {{month: [0, 1]}}
-// => month_0, month_1
-
 const getBandInformation = (selector) => {
   const combinedBands = Object.keys(selector)
     .filter((key) => Array.isArray(selector[key]))


### PR DESCRIPTION
Where we were previously assuming only one selector key was present, extend logic to support arbitrary numbers of selectors:
- fetch coordinates of all selector keys
- programmatically construct `indexes` to pass to `data.pick`
- construct arbitrary number of `bands` based on `selector`

See [testing branch](https://github.com/carbonplan/maps/pull/7) for demo integration