### PR TITLE
infer dimensions

### DIFF
--- a/demo/pages/index.js
+++ b/demo/pages/index.js
@@ -55,7 +55,6 @@ const Index = () => {
               'https://storage.googleapis.com/carbonplan-share/maps-demo/4d/tavg-prec-month'
             }
             variable={'climate'}
-            dimensions={['band', 'month', 'y', 'x']}
             selector={{ month, band }}
             setRegionData={setRegionData}
           />

--- a/package-lock.json
+++ b/package-lock.json
@@ -5045,6 +5045,9 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.6"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -6596,6 +6599,9 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.3.tgz",
       "integrity": "sha512-Au92NuznFklgQCUcV96iXlxUbHuB1vQMaH76DHl5M11TotjOHwqk9CwcrT78+Tnv4FN9uTBxq6p4EJoYkpyekg==",
       "dev": true,
+      "dependencies": {
+        "fsevents": "~2.3.2"
+      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -33,7 +33,6 @@ export const createTiles = (regl, opts) => {
     opacity,
     display,
     variable,
-    dimensions,
     selector = {},
     uniforms: customUniforms = {},
     frag: customFrag,
@@ -62,8 +61,6 @@ export const createTiles = (regl, opts) => {
       )
     }
 
-    this.dimensions = dimensions
-    this.ndim = dimensions.length
     this.bands = getBands(variable, selector)
 
     customUniforms = Object.keys(customUniforms)
@@ -105,6 +102,8 @@ export const createTiles = (regl, opts) => {
         if (mode === 'texture') {
           this.count = 6
         }
+        this.dimensions = metadata.metadata[`${levels[0]}/${variable}/.zattrs`]['_ARRAY_DIMENSIONS']
+        this.ndim = this.dimensions.length
 
         levels.map((z) => {
           Array(Math.pow(2, z))
@@ -144,7 +143,7 @@ export const createTiles = (regl, opts) => {
             Object.keys(selector).map(
               (key) =>
                 new Promise((innerResolve) => {
-                  loaders['0/' + key]([0], (err, chunk) => {
+                  loaders[`${levels[0]}/${key}`]([0], (err, chunk) => {
                     const coordinates = Array.from(chunk.data)
                     this.coordinates[key] = coordinates
                     innerResolve()

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -102,7 +102,10 @@ export const createTiles = (regl, opts) => {
         if (mode === 'texture') {
           this.count = 6
         }
-        this.dimensions = metadata.metadata[`${levels[0]}/${variable}/.zattrs`]['_ARRAY_DIMENSIONS']
+        this.dimensions =
+          metadata.metadata[`${levels[0]}/${variable}/.zattrs`][
+            '_ARRAY_DIMENSIONS'
+          ]
         this.ndim = this.dimensions.length
 
         levels.map((z) => {


### PR DESCRIPTION
Tiny PR to infer dimensions from Zarr metadata, further simplifying our boilerplate and demos. Also changed the assumption of level `0` to an assumption of `levels[0]`.  While still assuming the dimensions are the same across levels, this at least relaxes the assumption that a level named `0` exists.