### PR TITLE
[draft] Testing zarr.js integration

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -12,7 +12,7 @@
         "@carbonplan/colormaps": "^2.0.0",
         "@carbonplan/components": "^10.0.0",
         "@carbonplan/icons": "^1.0.0",
-        "@carbonplan/maps": "^1.0.0",
+        "@carbonplan/maps": "1.0.0-develop.10",
         "@carbonplan/theme": "^7.0.0",
         "next": "^11.1.0",
         "react": "^17.0.2",
@@ -478,9 +478,9 @@
       }
     },
     "node_modules/@carbonplan/maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@carbonplan/maps/-/maps-1.0.0.tgz",
-      "integrity": "sha512-OgtT0lBRSinq25eRpT1oy2e8SDYHWDXX21Wuo3UzzcGiczDphqPt4KMI+iWhFXDXaURibCXXVqEQhN2kRKtEoQ==",
+      "version": "1.0.0-develop.10",
+      "resolved": "https://registry.npmjs.org/@carbonplan/maps/-/maps-1.0.0-develop.10.tgz",
+      "integrity": "sha512-fW4F+79Sft0NNi5bEVQ25uV2oJDT6rlyOs1BMVrarhTOg/ylpnJV1tSUGJyxbfrP8kSmWNjVtoJw5Ywg2BKdOQ==",
       "dependencies": {
         "@turf/turf": "^6.5.0",
         "d3-geo": "^2.0.2",
@@ -490,7 +490,7 @@
         "regl": "^2.1.0",
         "uuid": "^8.3.2",
         "xhr-request": "^1.1.0",
-        "zarr-js": "^2.1.1"
+        "zarr": "^0.5.1"
       },
       "peerDependencies": {
         "react": "^16.14.0 || ^17.0.2",
@@ -2712,14 +2712,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.4",
       "integrity": "sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA==",
@@ -2770,11 +2762,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/bit-twiddle": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
-      "integrity": "sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4="
     },
     "node_modules/bn.js": {
       "version": "5.2.0",
@@ -2929,11 +2916,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
       }
-    },
-    "node_modules/cartesian-product": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cartesian-product/-/cartesian-product-2.1.2.tgz",
-      "integrity": "sha1-yahGLFSrGaDF/TIZKSLiOatMpP0="
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -3187,14 +3169,6 @@
       "version": "3.0.8",
       "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
     },
-    "node_modules/cwise-compiler": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
-      "integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
-      "dependencies": {
-        "uniq": "^1.0.0"
-      }
-    },
     "node_modules/d3-array": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
@@ -3335,11 +3309,6 @@
         "url": "https://bevry.me/fund"
       }
     },
-    "node_modules/dup": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dup/-/dup-1.0.0.tgz",
-      "integrity": "sha1-UfxaxoX4GWRp3wuQXpNLIK9bQCk="
-    },
     "node_modules/earcut": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
@@ -3455,6 +3424,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -4177,11 +4151,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
@@ -4331,24 +4300,6 @@
       "dependencies": {
         "iota-array": "^1.0.0",
         "is-buffer": "^1.0.2"
-      }
-    },
-    "node_modules/ndarray-ops": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/ndarray-ops/-/ndarray-ops-1.2.2.tgz",
-      "integrity": "sha1-WeiNLDKn7ryxvGkPrhQVeVV6YU4=",
-      "dependencies": {
-        "cwise-compiler": "^1.0.0"
-      }
-    },
-    "node_modules/ndarray-scratch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ndarray-scratch/-/ndarray-scratch-1.2.0.tgz",
-      "integrity": "sha1-YwRjbWLrqT20cnrBPGkzQdulDgE=",
-      "dependencies": {
-        "ndarray": "^1.0.14",
-        "ndarray-ops": "^1.2.1",
-        "typedarray-pool": "^1.0.2"
       }
     },
     "node_modules/next": {
@@ -4594,6 +4545,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/numcodecs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.2.2.tgz",
+      "integrity": "sha512-Y5K8mv80yb4MgVpcElBkUeMZqeE4TrovxRit/dTZvoRl6YkB6WEjY+fiUjGCblITnt3T3fmrDg8yRWu0gOLjhQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
@@ -4657,6 +4616,14 @@
       "version": "0.3.0",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
@@ -4691,6 +4658,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.2.0.tgz",
+      "integrity": "sha512-B2LXNONcyn/G6uz2UBFsGjmSa0e/br3jznlzhEyCXg56c7VhEpiT2pZxGOfv32Q3FSyugAdys9KGpsv3kV+Sbg==",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "p-timeout": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-try": {
@@ -5579,15 +5569,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/typedarray-pool": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.2.0.tgz",
-      "integrity": "sha512-YTSQbzX43yvtpfRtIDAYygoYtgT+Rpjuxy9iOpczrjpXLgGoyG7aS5USJXV2d3nn8uHTeb9rXDvzS27zUg5KYQ==",
-      "dependencies": {
-        "bit-twiddle": "^1.0.0",
-        "dup": "^1.0.0"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
       "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
@@ -5600,11 +5581,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/uniq": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -5810,17 +5786,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/zarr-js": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-2.1.1.tgz",
-      "integrity": "sha512-IrlK/XtLJAPbDRCnhBs2R360O8A4pUbKcyBkS/D30Y8qqIMH/wNA7Nf0o33cdjZ8Tth2HxEWuKcxlOc19M8XWQ==",
+    "node_modules/zarr": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.5.1.tgz",
+      "integrity": "sha512-eL7S5gza/ednVr9wJMd5UF7jcc72qgMlMxuHbFYkWWX9dvb7n0SJL6PS3dCJ5TqyRSamCpAm+ssuodcL4uBTUQ==",
       "dependencies": {
-        "async": "^2.6.2",
-        "cartesian-product": "^2.1.2",
-        "ndarray": "^1.0.18",
-        "ndarray-ops": "^1.2.2",
-        "ndarray-scratch": "^1.2.0",
-        "pako": "^1.0.10"
+        "numcodecs": "^0.2.1",
+        "p-queue": "6.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     }
   },
@@ -6153,9 +6128,9 @@
       "requires": {}
     },
     "@carbonplan/maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@carbonplan/maps/-/maps-1.0.0.tgz",
-      "integrity": "sha512-OgtT0lBRSinq25eRpT1oy2e8SDYHWDXX21Wuo3UzzcGiczDphqPt4KMI+iWhFXDXaURibCXXVqEQhN2kRKtEoQ==",
+      "version": "1.0.0-develop.10",
+      "resolved": "https://registry.npmjs.org/@carbonplan/maps/-/maps-1.0.0-develop.10.tgz",
+      "integrity": "sha512-fW4F+79Sft0NNi5bEVQ25uV2oJDT6rlyOs1BMVrarhTOg/ylpnJV1tSUGJyxbfrP8kSmWNjVtoJw5Ywg2BKdOQ==",
       "requires": {
         "@turf/turf": "^6.5.0",
         "d3-geo": "^2.0.2",
@@ -6165,7 +6140,7 @@
         "regl": "^2.1.0",
         "uuid": "^8.3.2",
         "xhr-request": "^1.1.0",
-        "zarr-js": "^2.1.1"
+        "zarr": "^0.5.1"
       }
     },
     "@carbonplan/theme": {
@@ -7955,14 +7930,6 @@
       "version": "0.13.2",
       "integrity": "sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA=="
     },
-    "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
-    },
     "available-typed-arrays": {
       "version": "1.0.4",
       "integrity": "sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA=="
@@ -7987,11 +7954,6 @@
     "binary-extensions": {
       "version": "2.2.0",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
-    },
-    "bit-twiddle": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
-      "integrity": "sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4="
     },
     "bn.js": {
       "version": "5.2.0",
@@ -8120,11 +8082,6 @@
     "caniuse-lite": {
       "version": "1.0.30001252",
       "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw=="
-    },
-    "cartesian-product": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cartesian-product/-/cartesian-product-2.1.2.tgz",
-      "integrity": "sha1-yahGLFSrGaDF/TIZKSLiOatMpP0="
     },
     "chalk": {
       "version": "2.4.2",
@@ -8349,14 +8306,6 @@
       "version": "3.0.8",
       "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
     },
-    "cwise-compiler": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
-      "integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
-      "requires": {
-        "uniq": "^1.0.0"
-      }
-    },
     "d3-array": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
@@ -8472,11 +8421,6 @@
       "version": "4.19.0",
       "integrity": "sha512-fRA+BaAWOR/yr/t7T9E9GJztHPeFjj8U35ajyAjCDtAAnTn1Rc1f6W6VGPJrO1tkQv9zWu+JRof7z6oQtiYVFQ=="
     },
-    "dup": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dup/-/dup-1.0.0.tgz",
-      "integrity": "sha1-UfxaxoX4GWRp3wuQXpNLIK9bQCk="
-    },
     "earcut": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.3.tgz",
@@ -8570,6 +8514,11 @@
     "etag": {
       "version": "1.8.1",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "events": {
       "version": "3.3.0",
@@ -9073,11 +9022,6 @@
         "p-locate": "^4.1.0"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lodash.sortby": {
       "version": "4.7.0",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
@@ -9205,24 +9149,6 @@
       "requires": {
         "iota-array": "^1.0.0",
         "is-buffer": "^1.0.2"
-      }
-    },
-    "ndarray-ops": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/ndarray-ops/-/ndarray-ops-1.2.2.tgz",
-      "integrity": "sha1-WeiNLDKn7ryxvGkPrhQVeVV6YU4=",
-      "requires": {
-        "cwise-compiler": "^1.0.0"
-      }
-    },
-    "ndarray-scratch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ndarray-scratch/-/ndarray-scratch-1.2.0.tgz",
-      "integrity": "sha1-YwRjbWLrqT20cnrBPGkzQdulDgE=",
-      "requires": {
-        "ndarray": "^1.0.14",
-        "ndarray-ops": "^1.2.1",
-        "typedarray-pool": "^1.0.2"
       }
     },
     "next": {
@@ -9440,6 +9366,11 @@
       "version": "3.0.0",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
+    "numcodecs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.2.2.tgz",
+      "integrity": "sha512-Y5K8mv80yb4MgVpcElBkUeMZqeE4TrovxRit/dTZvoRl6YkB6WEjY+fiUjGCblITnt3T3fmrDg8yRWu0gOLjhQ=="
+    },
     "object-assign": {
       "version": "4.1.1",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
@@ -9482,6 +9413,11 @@
       "version": "0.3.0",
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
     },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
     "p-limit": {
       "version": "3.1.0",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
@@ -9503,6 +9439,23 @@
             "p-try": "^2.0.0"
           }
         }
+      }
+    },
+    "p-queue": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.2.0.tgz",
+      "integrity": "sha512-B2LXNONcyn/G6uz2UBFsGjmSa0e/br3jznlzhEyCXg56c7VhEpiT2pZxGOfv32Q3FSyugAdys9KGpsv3kV+Sbg==",
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "p-timeout": "^3.1.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -10190,15 +10143,6 @@
       "version": "0.7.1",
       "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="
     },
-    "typedarray-pool": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.2.0.tgz",
-      "integrity": "sha512-YTSQbzX43yvtpfRtIDAYygoYtgT+Rpjuxy9iOpczrjpXLgGoyG7aS5USJXV2d3nn8uHTeb9rXDvzS27zUg5KYQ==",
-      "requires": {
-        "bit-twiddle": "^1.0.0",
-        "dup": "^1.0.0"
-      }
-    },
     "unbox-primitive": {
       "version": "1.0.1",
       "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
@@ -10208,11 +10152,6 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
-    },
-    "uniq": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -10377,17 +10316,13 @@
       "version": "0.1.0",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     },
-    "zarr-js": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-2.1.1.tgz",
-      "integrity": "sha512-IrlK/XtLJAPbDRCnhBs2R360O8A4pUbKcyBkS/D30Y8qqIMH/wNA7Nf0o33cdjZ8Tth2HxEWuKcxlOc19M8XWQ==",
+    "zarr": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.5.1.tgz",
+      "integrity": "sha512-eL7S5gza/ednVr9wJMd5UF7jcc72qgMlMxuHbFYkWWX9dvb7n0SJL6PS3dCJ5TqyRSamCpAm+ssuodcL4uBTUQ==",
       "requires": {
-        "async": "^2.6.2",
-        "cartesian-product": "^2.1.2",
-        "ndarray": "^1.0.18",
-        "ndarray-ops": "^1.2.2",
-        "ndarray-scratch": "^1.2.0",
-        "pako": "^1.0.10"
+        "numcodecs": "^0.2.1",
+        "p-queue": "6.2.0"
       }
     }
   }

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -12,7 +12,7 @@
         "@carbonplan/colormaps": "^2.0.0",
         "@carbonplan/components": "^10.0.0",
         "@carbonplan/icons": "^1.0.0",
-        "@carbonplan/maps": "1.0.0-alpha.20",
+        "@carbonplan/maps": "^1.0.0",
         "@carbonplan/theme": "^7.0.0",
         "next": "^11.1.0",
         "react": "^17.0.2",
@@ -478,9 +478,9 @@
       }
     },
     "node_modules/@carbonplan/maps": {
-      "version": "1.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@carbonplan/maps/-/maps-1.0.0-alpha.20.tgz",
-      "integrity": "sha512-tAmRQw6h55z+jU0Jzj/tpu7Lb7iLSUiVNdv5oFHSwmzKGYSsX+ygDx9HnbnIW1gCdUZT3NOC8weNfhd7U62ZfQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@carbonplan/maps/-/maps-1.0.0.tgz",
+      "integrity": "sha512-OgtT0lBRSinq25eRpT1oy2e8SDYHWDXX21Wuo3UzzcGiczDphqPt4KMI+iWhFXDXaURibCXXVqEQhN2kRKtEoQ==",
       "dependencies": {
         "@turf/turf": "^6.5.0",
         "d3-geo": "^2.0.2",
@@ -2953,7 +2953,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -6154,9 +6153,9 @@
       "requires": {}
     },
     "@carbonplan/maps": {
-      "version": "1.0.0-alpha.20",
-      "resolved": "https://registry.npmjs.org/@carbonplan/maps/-/maps-1.0.0-alpha.20.tgz",
-      "integrity": "sha512-tAmRQw6h55z+jU0Jzj/tpu7Lb7iLSUiVNdv5oFHSwmzKGYSsX+ygDx9HnbnIW1gCdUZT3NOC8weNfhd7U62ZfQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@carbonplan/maps/-/maps-1.0.0.tgz",
+      "integrity": "sha512-OgtT0lBRSinq25eRpT1oy2e8SDYHWDXX21Wuo3UzzcGiczDphqPt4KMI+iWhFXDXaURibCXXVqEQhN2kRKtEoQ==",
       "requires": {
         "@turf/turf": "^6.5.0",
         "d3-geo": "^2.0.2",

--- a/demo/package.json
+++ b/demo/package.json
@@ -15,7 +15,7 @@
     "@carbonplan/colormaps": "^2.0.0",
     "@carbonplan/components": "^10.0.0",
     "@carbonplan/icons": "^1.0.0",
-    "@carbonplan/maps": "^1.0.0",
+    "@carbonplan/maps": "1.0.0-develop.10",
     "@carbonplan/theme": "^7.0.0",
     "next": "^11.1.0",
     "react": "^17.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@carbonplan/maps",
-  "version": "1.0.0",
+  "version": "1.0.0-develop.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@carbonplan/maps",
-      "version": "1.0.0",
+      "version": "1.0.0-develop.10",
       "license": "MIT",
       "dependencies": {
         "@turf/turf": "^6.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@carbonplan/maps",
-  "version": "1.0.0-alpha.19",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@carbonplan/maps",
-      "version": "1.0.0-alpha.19",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@turf/turf": "^6.5.0",
@@ -17,7 +17,7 @@
         "regl": "^2.1.0",
         "uuid": "^8.3.2",
         "xhr-request": "^1.1.0",
-        "zarr-js": "^2.1.1"
+        "zarr": "^0.5.1"
       },
       "devDependencies": {
         "microbundle": "^0.13.0",
@@ -3548,14 +3548,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "dependencies": {
-        "lodash": "^4.17.14"
-      }
-    },
     "node_modules/asyncro": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/asyncro/-/asyncro-3.0.0.tgz",
@@ -3685,11 +3677,6 @@
         "node": "*"
       }
     },
-    "node_modules/bit-twiddle": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
-      "integrity": "sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4="
-    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -3818,11 +3805,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
       }
-    },
-    "node_modules/cartesian-product": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cartesian-product/-/cartesian-product-2.1.2.tgz",
-      "integrity": "sha1-yahGLFSrGaDF/TIZKSLiOatMpP0="
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -4160,14 +4142,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/cwise-compiler": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
-      "integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
-      "dependencies": {
-        "uniq": "^1.0.0"
-      }
-    },
     "node_modules/d3-array": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
@@ -4331,11 +4305,6 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
-    "node_modules/dup": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dup/-/dup-1.0.0.tgz",
-      "integrity": "sha1-UfxaxoX4GWRp3wuQXpNLIK9bQCk="
-    },
     "node_modules/duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -4419,8 +4388,7 @@
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "node_modules/figures": {
       "version": "1.7.0",
@@ -5046,9 +5014,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -5119,11 +5084,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -5443,24 +5403,6 @@
         "is-buffer": "^1.0.2"
       }
     },
-    "node_modules/ndarray-ops": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/ndarray-ops/-/ndarray-ops-1.2.2.tgz",
-      "integrity": "sha1-WeiNLDKn7ryxvGkPrhQVeVV6YU4=",
-      "dependencies": {
-        "cwise-compiler": "^1.0.0"
-      }
-    },
-    "node_modules/ndarray-scratch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ndarray-scratch/-/ndarray-scratch-1.2.0.tgz",
-      "integrity": "sha1-YwRjbWLrqT20cnrBPGkzQdulDgE=",
-      "dependencies": {
-        "ndarray": "^1.0.14",
-        "ndarray-ops": "^1.2.1",
-        "typedarray-pool": "^1.0.2"
-      }
-    },
     "node_modules/node-releases": {
       "version": "1.1.75",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
@@ -5507,6 +5449,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/numcodecs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.2.2.tgz",
+      "integrity": "sha512-Y5K8mv80yb4MgVpcElBkUeMZqeE4TrovxRit/dTZvoRl6YkB6WEjY+fiUjGCblITnt3T3fmrDg8yRWu0gOLjhQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/object-assign": {
@@ -5570,7 +5520,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -5622,7 +5571,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
       "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-      "dev": true,
       "dependencies": {
         "p-finally": "^1.0.0"
       },
@@ -5638,11 +5586,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -6600,9 +6543,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.56.3.tgz",
       "integrity": "sha512-Au92NuznFklgQCUcV96iXlxUbHuB1vQMaH76DHl5M11TotjOHwqk9CwcrT78+Tnv4FN9uTBxq6p4EJoYkpyekg==",
       "dev": true,
-      "dependencies": {
-        "fsevents": "~2.3.2"
-      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -7186,15 +7126,6 @@
       "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.3.tgz",
       "integrity": "sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA=="
     },
-    "node_modules/typedarray-pool": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.2.0.tgz",
-      "integrity": "sha512-YTSQbzX43yvtpfRtIDAYygoYtgT+Rpjuxy9iOpczrjpXLgGoyG7aS5USJXV2d3nn8uHTeb9rXDvzS27zUg5KYQ==",
-      "dependencies": {
-        "bit-twiddle": "^1.0.0",
-        "dup": "^1.0.0"
-      }
-    },
     "node_modules/typescript": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
@@ -7247,11 +7178,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/uniq": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "node_modules/uniqs": {
       "version": "2.0.0",
@@ -7354,17 +7280,28 @@
         "node": ">= 6"
       }
     },
-    "node_modules/zarr-js": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-2.1.1.tgz",
-      "integrity": "sha512-IrlK/XtLJAPbDRCnhBs2R360O8A4pUbKcyBkS/D30Y8qqIMH/wNA7Nf0o33cdjZ8Tth2HxEWuKcxlOc19M8XWQ==",
+    "node_modules/zarr": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.5.1.tgz",
+      "integrity": "sha512-eL7S5gza/ednVr9wJMd5UF7jcc72qgMlMxuHbFYkWWX9dvb7n0SJL6PS3dCJ5TqyRSamCpAm+ssuodcL4uBTUQ==",
       "dependencies": {
-        "async": "^2.6.2",
-        "cartesian-product": "^2.1.2",
-        "ndarray": "^1.0.18",
-        "ndarray-ops": "^1.2.2",
-        "ndarray-scratch": "^1.2.0",
-        "pako": "^1.0.10"
+        "numcodecs": "^0.2.1",
+        "p-queue": "6.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/zarr/node_modules/p-queue": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.2.0.tgz",
+      "integrity": "sha512-B2LXNONcyn/G6uz2UBFsGjmSa0e/br3jznlzhEyCXg56c7VhEpiT2pZxGOfv32Q3FSyugAdys9KGpsv3kV+Sbg==",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "p-timeout": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   },
@@ -9987,14 +9924,6 @@
         "color-convert": "^1.9.0"
       }
     },
-    "async": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-      "requires": {
-        "lodash": "^4.17.14"
-      }
-    },
     "asyncro": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/asyncro/-/asyncro-3.0.0.tgz",
@@ -10092,11 +10021,6 @@
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true
     },
-    "bit-twiddle": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
-      "integrity": "sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4="
-    },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -10190,11 +10114,6 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001257.tgz",
       "integrity": "sha512-JN49KplOgHSXpIsVSF+LUyhD8PUp6xPpAXeRrrcBh4KBeP7W864jHn6RvzJgDlrReyeVjMFJL3PLpPvKIxlIHA==",
       "dev": true
-    },
-    "cartesian-product": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cartesian-product/-/cartesian-product-2.1.2.tgz",
-      "integrity": "sha1-yahGLFSrGaDF/TIZKSLiOatMpP0="
     },
     "chalk": {
       "version": "2.4.2",
@@ -10466,14 +10385,6 @@
         "css-tree": "^1.1.2"
       }
     },
-    "cwise-compiler": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
-      "integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
-      "requires": {
-        "uniq": "^1.0.0"
-      }
-    },
     "d3-array": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
@@ -10596,11 +10507,6 @@
         "domhandler": "^4.2.0"
       }
     },
-    "dup": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dup/-/dup-1.0.0.tgz",
-      "integrity": "sha1-UfxaxoX4GWRp3wuQXpNLIK9bQCk="
-    },
     "duplexer": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
@@ -10666,8 +10572,7 @@
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "figures": {
       "version": "1.7.0",
@@ -11199,11 +11104,6 @@
         "p-locate": "^4.1.0"
       }
     },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -11473,24 +11373,6 @@
         "is-buffer": "^1.0.2"
       }
     },
-    "ndarray-ops": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/ndarray-ops/-/ndarray-ops-1.2.2.tgz",
-      "integrity": "sha1-WeiNLDKn7ryxvGkPrhQVeVV6YU4=",
-      "requires": {
-        "cwise-compiler": "^1.0.0"
-      }
-    },
-    "ndarray-scratch": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ndarray-scratch/-/ndarray-scratch-1.2.0.tgz",
-      "integrity": "sha1-YwRjbWLrqT20cnrBPGkzQdulDgE=",
-      "requires": {
-        "ndarray": "^1.0.14",
-        "ndarray-ops": "^1.2.1",
-        "typedarray-pool": "^1.0.2"
-      }
-    },
     "node-releases": {
       "version": "1.1.75",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.75.tgz",
@@ -11523,6 +11405,11 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
+    },
+    "numcodecs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.2.2.tgz",
+      "integrity": "sha512-Y5K8mv80yb4MgVpcElBkUeMZqeE4TrovxRit/dTZvoRl6YkB6WEjY+fiUjGCblITnt3T3fmrDg8yRWu0gOLjhQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -11566,8 +11453,7 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
       "version": "2.3.0",
@@ -11601,7 +11487,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
       "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-      "dev": true,
       "requires": {
         "p-finally": "^1.0.0"
       }
@@ -11611,11 +11496,6 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
-    },
-    "pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -12747,15 +12627,6 @@
       "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.3.tgz",
       "integrity": "sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA=="
     },
-    "typedarray-pool": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.2.0.tgz",
-      "integrity": "sha512-YTSQbzX43yvtpfRtIDAYygoYtgT+Rpjuxy9iOpczrjpXLgGoyG7aS5USJXV2d3nn8uHTeb9rXDvzS27zUg5KYQ==",
-      "requires": {
-        "bit-twiddle": "^1.0.0",
-        "dup": "^1.0.0"
-      }
-    },
     "typescript": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.3.tgz",
@@ -12789,11 +12660,6 @@
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz",
       "integrity": "sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==",
       "dev": true
-    },
-    "uniq": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "uniqs": {
       "version": "2.0.0",
@@ -12880,17 +12746,24 @@
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "dev": true
     },
-    "zarr-js": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-2.1.1.tgz",
-      "integrity": "sha512-IrlK/XtLJAPbDRCnhBs2R360O8A4pUbKcyBkS/D30Y8qqIMH/wNA7Nf0o33cdjZ8Tth2HxEWuKcxlOc19M8XWQ==",
+    "zarr": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.5.1.tgz",
+      "integrity": "sha512-eL7S5gza/ednVr9wJMd5UF7jcc72qgMlMxuHbFYkWWX9dvb7n0SJL6PS3dCJ5TqyRSamCpAm+ssuodcL4uBTUQ==",
       "requires": {
-        "async": "^2.6.2",
-        "cartesian-product": "^2.1.2",
-        "ndarray": "^1.0.18",
-        "ndarray-ops": "^1.2.2",
-        "ndarray-scratch": "^1.2.0",
-        "pako": "^1.0.10"
+        "numcodecs": "^0.2.1",
+        "p-queue": "6.2.0"
+      },
+      "dependencies": {
+        "p-queue": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.2.0.tgz",
+          "integrity": "sha512-B2LXNONcyn/G6uz2UBFsGjmSa0e/br3jznlzhEyCXg56c7VhEpiT2pZxGOfv32Q3FSyugAdys9KGpsv3kV+Sbg==",
+          "requires": {
+            "eventemitter3": "^4.0.0",
+            "p-timeout": "^3.1.0"
+          }
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "regl": "^2.1.0",
     "uuid": "^8.3.2",
     "xhr-request": "^1.1.0",
-    "zarr-js": "^2.1.1"
+    "zarr": "^0.5.1"
   },
   "peerDependencies": {
     "react": "^16.14.0 || ^17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbonplan/maps",
-  "version": "1.0.0",
+  "version": "1.0.0-develop.10",
   "description": "interactive data-driven web maps",
   "main": "dst/index.js",
   "module": "dst/index.esm.js",

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -144,7 +144,7 @@ export const createTiles = (regl, opts) => {
 
     customUniforms.forEach((k) => (uniforms[k] = regl.this(k)))
 
-    initializeData(variable, selector).then(
+    this.initialized = initializeData(variable, selector).then(
       ({ levels, maxZoom, tileSize, dimensions, loaders, coordinates }) => {
         const position = getPositions(tileSize, mode)
         this.position = regl.buffer(position)
@@ -194,6 +194,8 @@ export const createTiles = (regl, opts) => {
                 })
             })
         })
+
+        return true
       }
     )
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -383,7 +383,7 @@ export const setObjectValues = (obj, keys, value) => {
  * @param {x} number x coordinate at which to lookup values
  * @param {y} number y coordinate at which to lookup values
  * @param {Array<string>} dimensions to iterate over
- * @param {{[dimension]: Array<any>}} coordinate names to use for `keys`
+ * @param {{[dimension]: Array<any>}} coordinates names to use for `keys`
  * @returns Array of containing `keys: Array<string>` and `value: any` (value of `data` corresponding to `keys`)
  */
 export const getValuesToSet = (data, x, y, dimensions, coordinates) => {


### PR DESCRIPTION
### Background
We're currently using our small library [`zarr-js`](https://github.com/freeman-lab/zarr-js) to read Zarr data in this project, but there are multiple other projects for loading Zarr data in the browser and it would be great to standardize on one (some of which are helpfully aggregated [here](https://github.com/manzt/zarr-bundlesize)!). This PR serves as an exploration for swapping out `zarr-js` with another implementation, [`zarr.js`](https://github.com/gzuidhof/zarr.js/).

### Defining our needs
- first class support for the Zarr v2 spec
- support for consolidated metadata
- string support
- similar built size in our Next.js apps to what we're able to achieve today

### Build size
We had been operating under the assumption that the minimal implementation of features in `zarr-js` would lead to a smaller build size in our Next.js apps. This is roughly confirmed by comparing the build outputs of the demo app.
#### on `main` (using `maps@1.0.0`)
```
Page                              Size     First Load JS
┌ ○ /                             440 kB          523 kB
├   /_app                         0 B              83 kB
└ ○ /404                          194 B          83.2 kB
+ First Load JS shared by all     83 kB
  ├ chunks/framework.895f06.js    42 kB
  ├ chunks/main.222191.js         23.4 kB
  ├ chunks/pages/_app.cf5980.js   16.8 kB
  ├ chunks/webpack.0e0f5c.js      870 B
  └ css/2e5f5d74649ef328ca3d.css  3.35 kB
```
#### on this branch (using `maps@1.0.0-develop.10`)
```
Page                              Size     First Load JS
┌ ○ /                             593 kB          676 kB
├   /_app                         0 B              83 kB
└ ○ /404                          194 B          83.2 kB
+ First Load JS shared by all     83 kB
  ├ chunks/framework.895f06.js    42 kB
  ├ chunks/main.222191.js         23.4 kB
  ├ chunks/pages/_app.cf5980.js   16.8 kB
  ├ chunks/webpack.0cb069.js      825 B
  └ css/2e5f5d74649ef328ca3d.css  3.35 kB
```