### PR TITLE
improved rendering

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,9 @@
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: 'v2.2.1'
+    rev: 'v2.3.0'
     hooks:
       - id: prettier
+        language_version: system
         files: "\\.(\
           css|less|scss\
           |graphql|gql\
@@ -14,9 +15,10 @@ repos:
           |yaml|yml\
           )$"
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: 'v2.2.1'
+    rev: 'v2.3.0'
     hooks:
       - id: prettier
+        language_version: system
         name: prettier-markdown
         entry: prettier --write --parser mdx
         files: "\\.(\

--- a/demo/package.json
+++ b/demo/package.json
@@ -15,7 +15,7 @@
     "@carbonplan/colormaps": "^2.0.0",
     "@carbonplan/components": "^10.0.0",
     "@carbonplan/icons": "^1.0.0",
-    "@carbonplan/maps": "^1.0.0",
+    "@carbonplan/maps": "1.0.0-develop.11",
     "@carbonplan/theme": "^7.0.0",
     "next": "^11.1.0",
     "react": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbonplan/maps",
-  "version": "1.0.0",
+  "version": "1.0.0-develop.11",
   "description": "interactive data-driven web maps",
   "main": "dst/index.js",
   "module": "dst/index.esm.js",

--- a/src/raster.js
+++ b/src/raster.js
@@ -44,7 +44,7 @@ const Raster = (props) => {
   }
 
   useEffect(() => {
-    tiles.current = createTiles(regl, props)
+    tiles.current = createTiles(regl, map, props)
   }, [])
 
   useEffect(() => {
@@ -57,7 +57,7 @@ const Raster = (props) => {
   useEffect(() => {
     if (map.loaded()) {
       tiles.current.updateCamera(camera.current)
-      tiles.current.draw()
+      map.triggerRepaint()
     }
   }, Object.values(selector))
 
@@ -81,17 +81,17 @@ const Raster = (props) => {
   // Because the regl dimensions are updated via polling, tiles drawn on
   // map `render` will use stale dimensions under some race conditions.
   useEffect(() => {
-    tiles.current.redraw()
+    map.triggerRepaint()
   }, [viewport])
 
   useEffect(() => {
     tiles.current.updateUniforms({ display, opacity, clim, ...uniforms })
-    tiles.current.redraw()
+    map.triggerRepaint()
   }, [display, opacity, clim, ...Object.values(uniforms)])
 
   useEffect(() => {
     tiles.current.updateColormap({ colormap })
-    tiles.current.draw()
+    map.triggerRepaint()
   }, [colormap])
 
   useEffect(() => {

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -79,10 +79,10 @@ export const createTiles = (regl, map, opts) => {
 
     if (mode === 'texture') {
       primitive = 'triangles'
-      const emptyTexture = ndarray(new Float32Array(Array(1).fill(fillValue)), [
-        1,
-        1,
-      ])
+      const emptyTexture = ndarray(
+        new Float32Array(Array(1).fill(fillValue)),
+        [1, 1]
+      )
       initialize = () => regl.texture(emptyTexture)
       this.bands.forEach((k) => (uniforms[k] = regl.prop(k)))
     }

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -23,7 +23,7 @@ import {
   setObjectValues,
 } from './utils'
 
-export const createTiles = (regl, opts) => {
+export const createTiles = (regl, map, opts) => {
   return new Tiles(opts)
 
   function Tiles({
@@ -262,15 +262,7 @@ export const createTiles = (regl, opts) => {
     }
 
     this.draw = () => {
-      if (this.display) {
-        this.drawTiles(this.getProps())
-        this.renderedTick = this.tick
-      } else {
-        regl.clear({
-          color: [0, 0, 0, 0],
-          depth: 1,
-        })
-      }
+      this.drawTiles(this.getProps())
     }
 
     this.updateCamera = ({ center, zoom, viewport, selector }) => {
@@ -312,7 +304,7 @@ export const createTiles = (regl, opts) => {
                 tile.cache.buffer = true
                 tile.cache.selector = selectorHash
                 tile.loading = false
-                this.redraw()
+                map.triggerRepaint()
               })
             }
           }
@@ -321,7 +313,7 @@ export const createTiles = (regl, opts) => {
               tile.buffers[k](this.accessors[k](tile.data, selector))
             })
             tile.cache.selector = selectorHash
-            this.redraw()
+            map.triggerRepaint()
           }
         }
       })
@@ -402,6 +394,9 @@ export const createTiles = (regl, opts) => {
       Object.keys(props).forEach((k) => {
         this[k] = props[k]
       })
+      if (!this.display) {
+        this.opacity = 0
+      }
     }
 
     this.updateColormap = ({ colormap }) => {
@@ -411,16 +406,5 @@ export const createTiles = (regl, opts) => {
         shape: [255, 1],
       })
     }
-
-    this.redraw = () => {
-      if (this.renderedTick !== this.tick) {
-        this.draw()
-      }
-    }
-
-    this.renderedTick = 0
-    regl.frame(({ tick }) => {
-      this.tick = tick
-    })
   }
 }


### PR DESCRIPTION
With a fairly simple change, I believe this PR fixes several rendering related issues. 

Previously, we were rendering in two separate ways:

1) on every mapbox `render` we rendered our tiles via regl
2) on every prop change we rendered our tiles via regl

Route (1) is important to keep our tiles and the vector map layers synced, and works perfectly for zoom, pan, etc. updates. However, we have been running into issues with route (2) and react props, in particular, how to throttle our own rendering from rapid prop changes without missing prop changes (especially cascades of prop changes via `useEffect`).  We were concerned this would require a rethink of our render loop approach, especially if we also wanted to remain synced with mapbox.

While reading around the issue, however, I discovered the low-level [`triggerRepaint`](https://docs.mapbox.com/mapbox-gl-js/api/map/#map#triggerrepaint) method in `mapbox`, and I think it might solve our problems. 

The approach taken in this PR is to do all rendering through route (1). Specifically, on every prop change, we simply call `map.triggerRepaint()`. Because that trigger is itself throttled on the mapbox side, we can safely call it after any and all prop changes. And from initial testing, the implementation of `triggerRepaint` appears to both ensure the update is eventually called. In effect, we are relying entirely on `mapbox` for a global, throttled rendering loop. While we may swap that out eventually, it feels clean for now to have rendering driven from one route rather than two.

One other fix I've made at the same time is to remove our frame clearing entirely, and instead implement `display=false` by setting `opacity=0`. In some basic testing, this allows multiple `<Raster/>` components to be rendered together and separately turned on and off, whereas before setting `display=false` on one of them would remove the others.