### PR TITLE
Add setLoading callbacks to Raster and Map

### DIFF
--- a/src/loading/context.js
+++ b/src/loading/context.js
@@ -1,0 +1,41 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useRef,
+  useState,
+} from 'react'
+
+const LoadingContext = createContext({})
+
+export const useLoadingContext = () => {
+  return useContext(LoadingContext)
+}
+
+export const useSetLoading = () => {
+  const { values, setValue } = useLoadingContext()
+  const key = useRef(new Date().getTime())
+
+  const setLoading = useCallback(
+    (value) => {
+      setValue(key.current, value)
+    },
+    [key.current, setValue]
+  )
+
+  return { setLoading, loading: !!values[key.current] }
+}
+
+export const LoadingProvider = ({ children }) => {
+  const [loading, setLoading] = useState({})
+
+  const setValue = (key, value) => {
+    setLoading({ ...loading, [key]: value })
+  }
+
+  return (
+    <LoadingContext.Provider value={{ values: loading, setValue }}>
+      {children}
+    </LoadingContext.Provider>
+  )
+}

--- a/src/loading/index.js
+++ b/src/loading/index.js
@@ -1,2 +1,2 @@
-export { LoadingProvider, useSetLoading } from './loading/context'
-export { LoadingUpdater } from './loading/loading-updater'
+export { LoadingProvider, useSetLoading } from './context'
+export { LoadingUpdater } from './loading-updater'

--- a/src/loading/index.js
+++ b/src/loading/index.js
@@ -1,0 +1,2 @@
+export { LoadingProvider, useSetLoading } from './loading/context'
+export { LoadingUpdater } from './loading/loading-updater'

--- a/src/loading/loading-updater.js
+++ b/src/loading/loading-updater.js
@@ -1,0 +1,14 @@
+import React, { useEffect } from 'react'
+
+import { useLoadingContext } from './context'
+
+export const LoadingUpdater = ({ setLoading }) => {
+  const { values } = useLoadingContext()
+  const loading = Object.keys(values).some((key) => values[key])
+
+  useEffect(() => {
+    setLoading(loading)
+  }, [loading])
+
+  return null
+}

--- a/src/map.js
+++ b/src/map.js
@@ -2,6 +2,7 @@ import React from 'react'
 import Mapbox from './mapbox'
 import Regl from './regl'
 import { RegionProvider } from './region/context'
+import { LoadingProvider, LoadingUpdater } from './loading'
 
 const Map = ({
   id,
@@ -17,6 +18,7 @@ const Map = ({
   extensions,
   glyphs,
   children,
+  setLoading,
 }) => {
   return (
     <div
@@ -49,7 +51,10 @@ const Map = ({
             zIndex: -1,
           }}
         >
-          <RegionProvider>{children}</RegionProvider>
+          <LoadingProvider>
+            {setLoading && <LoadingUpdater setLoading={setLoading} />}
+            <RegionProvider>{children}</RegionProvider>
+          </LoadingProvider>
         </Regl>
       </Mapbox>
     </div>

--- a/src/raster.js
+++ b/src/raster.js
@@ -4,6 +4,7 @@ import { useMapbox } from './mapbox'
 import { useControls } from './use-controls'
 import { createTiles } from './tiles'
 import { useRegion } from './region/context'
+import { useSetLoading } from './loading'
 
 const Raster = (props) => {
   const {
@@ -22,6 +23,7 @@ const Raster = (props) => {
   const { regl } = useRegl()
   const { map } = useMapbox()
   const { region } = useRegion()
+  const { setLoading } = useSetLoading()
   const tiles = useRef()
   const camera = useRef()
   const lastQueried = useRef()
@@ -45,6 +47,10 @@ const Raster = (props) => {
   useEffect(() => {
     tiles.current = createTiles(regl, {
       ...props,
+      setLoading: (value) => {
+        props.setLoading && props.setLoading(value)
+        setLoading(value)
+      },
       invalidate: () => {
         map.triggerRepaint()
       },


### PR DESCRIPTION
This PR adds optional `setLoading` callback props to `Raster` and `Map`, which can be used by consumers to indicate that data is being fetched for a particular map layer (`Raster`) or across all layers (`Map`).

A note on the current approach in `Map`: we are currently constructing and tracking a loading state (see _loading/context.js_) regardless of whether or not `setLoading` is being used on `Map`. We do this because we need an accurate record of the loading state to handle the case where `setLoading` goes from `undefined` -> a valid callback. As an alternative, we could throw an error when `setLoading` is not consistently provided/omitted.