### PR TITLE
Always triggerRepaint on unmount

### DIFF
--- a/src/raster.js
+++ b/src/raster.js
@@ -67,6 +67,7 @@ const Raster = (props) => {
         depth: 1,
       })
       map.off('render', callback)
+      map.triggerRepaint()
     }
   }, [])
 


### PR DESCRIPTION
Always `map.triggerRepaint()` when a `Raster` is unmounted to ensure that screen is not emptied by `regl.clear()` if other `Raster`s remain mounted

![raster_unmount](https://user-images.githubusercontent.com/12436887/144304526-1764df6a-deeb-4e18-9134-798d6a2fa87c.gif)
