### PR TITLE
Add optional index prop to handle reordering Rasters

### DIFF
--- a/src/raster.js
+++ b/src/raster.js
@@ -11,6 +11,7 @@ const Raster = (props) => {
     opacity = 1,
     clim,
     colormap,
+    index = null,
     regionOptions = {},
     selector = {},
     uniforms = {},
@@ -69,7 +70,7 @@ const Raster = (props) => {
       map.off('render', callback)
       map.triggerRepaint()
     }
-  }, [])
+  }, [index])
 
   useEffect(() => {
     tiles.current.updateSelector({ selector })

--- a/src/raster.js
+++ b/src/raster.js
@@ -11,7 +11,7 @@ const Raster = (props) => {
     opacity = 1,
     clim,
     colormap,
-    index = null,
+    index = 0,
     regionOptions = {},
     selector = {},
     uniforms = {},


### PR DESCRIPTION
This PR adds an optional index prop to `Raster`, which when changed will re-register the `map` `render` callback. This is necessary to change the effective rendering order of multiple `Raster`s (i.e. the order in which each layer is drawn).

Alternatives:
- we could restrict "reordering" to be performed by changing the `display`/`opacity` of `Raster` layers, but would not actually address the case where 0 <`opacity` < 1
- super open to different naming options for this prop (e.g. `orderKey`?)