### PR TITLE
[refactor] Avoid constructing full-dimension ndarray on region query

### DIFF
--- a/src/raster.js
+++ b/src/raster.js
@@ -92,11 +92,11 @@ const Raster = (props) => {
 
   useEffect(() => {
     if (region && regionOptions?.setData) {
-      queryRegion(region, regionOptions.selectData)
+      queryRegion(region, regionOptions.selector)
     }
   }, [
     regionOptions?.setData,
-    regionOptions?.selectData,
+    regionOptions?.selector,
     region,
     regionDataInvalidated,
   ])

--- a/src/raster.js
+++ b/src/raster.js
@@ -31,13 +31,13 @@ const Raster = (props) => {
 
   camera.current = { center: center, zoom: zoom }
 
-  const queryRegion = async (r) => {
+  const queryRegion = async (r, s) => {
     const queryStart = new Date().getTime()
     lastQueried.current = queryStart
 
     regionOptions.setData({ value: null })
 
-    const data = await tiles.current.queryRegion(r)
+    const data = await tiles.current.queryRegion(r, s)
 
     // Invoke callback as long as a more recent query has not already been initiated
     if (lastQueried.current === queryStart) {
@@ -92,9 +92,14 @@ const Raster = (props) => {
 
   useEffect(() => {
     if (region && regionOptions?.setData) {
-      queryRegion(region)
+      queryRegion(region, regionOptions.selectData)
     }
-  }, [regionOptions?.setData, region, regionDataInvalidated])
+  }, [
+    regionOptions?.setData,
+    regionOptions?.selectData,
+    region,
+    regionDataInvalidated,
+  ])
 
   return null
 }

--- a/src/raster.js
+++ b/src/raster.js
@@ -92,13 +92,14 @@ const Raster = (props) => {
 
   useEffect(() => {
     if (region && regionOptions?.setData) {
-      queryRegion(region, regionOptions.selector)
+      queryRegion(region, regionOptions.selector || selector)
     }
   }, [
     regionOptions?.setData,
-    regionOptions?.selector,
     region,
     regionDataInvalidated,
+    ...Object.values(regionOptions?.selector || {}),
+    ...Object.values(selector),
   ])
 
   return null

--- a/src/tile.js
+++ b/src/tile.js
@@ -223,7 +223,14 @@ class Tile {
 
       combinedIndices.forEach((indices) => {
         const keys = indices
-          .filter((el, i) => this.coordinates[this.dimensions[i]])
+          .filter((el, i) => {
+            const coordinates = this.coordinates[this.dimensions[i]]
+            const selectorValue = selector[this.dimensions[i]]
+            return (
+              coordinates &&
+              (Array.isArray(selectorValue) || selectorValue == undefined)
+            )
+          })
           .map((el, i) => this.coordinates[this.dimensions[i]][el])
         const chunkIndices = indices.map((el, i) =>
           ['x', 'y'].includes(this.dimensions[i])

--- a/src/tile.js
+++ b/src/tile.js
@@ -222,16 +222,19 @@ class Tile {
       )
 
       combinedIndices.forEach((indices) => {
-        const keys = indices
-          .filter((el, i) => {
-            const coordinates = this.coordinates[this.dimensions[i]]
-            const selectorValue = selector[this.dimensions[i]]
-            return (
-              coordinates &&
-              (Array.isArray(selectorValue) || selectorValue == undefined)
-            )
-          })
-          .map((el, i) => this.coordinates[this.dimensions[i]][el])
+        const keys = indices.reduce((accum, el, i) => {
+          const coordinates = this.coordinates[this.dimensions[i]]
+          const selectorValue = selector[this.dimensions[i]]
+
+          if (
+            coordinates &&
+            (Array.isArray(selectorValue) || selectorValue == undefined)
+          ) {
+            accum.push(coordinates[el])
+          }
+
+          return accum
+        }, [])
         const chunkIndices = indices.map((el, i) =>
           ['x', 'y'].includes(this.dimensions[i])
             ? el

--- a/src/tile.js
+++ b/src/tile.js
@@ -1,4 +1,3 @@
-import ndarray from 'ndarray'
 import {
   getBandInformation,
   getChunks,

--- a/src/tile.test.js
+++ b/src/tile.test.js
@@ -368,7 +368,7 @@ describe('Tile', () => {
         })
 
         expect(result).toHaveLength(1)
-        expect(result).toEqual([{ keys: [1], value: '0,0,0-0' }])
+        expect(result).toEqual([{ keys: [], value: '0,0,0-0' }])
       })
 
       it('handles array selector values', async () => {
@@ -377,13 +377,20 @@ describe('Tile', () => {
         // Load 1st chunk
         await tile.loadChunks([[0, 0, 0]])
 
-        const result = tile.getPointValues({
-          selector: { year: [1, 2, 3, 4, 5] },
-          point: [0, 0],
-        })
-
-        expect(result).toHaveLength(5)
-        expect(result).toEqual([
+        // Still includes keys when selector value has length 1
+        expect(
+          tile.getPointValues({
+            selector: { year: [1] },
+            point: [0, 0],
+          })
+        ).toEqual([{ keys: [1], value: '0,0,0-0' }])
+        // Also includes keys when selector value has length > 1
+        expect(
+          tile.getPointValues({
+            selector: { year: [1, 2, 3, 4, 5] },
+            point: [0, 0],
+          })
+        ).toEqual([
           { keys: [1], value: '0,0,0-0' },
           { keys: [2], value: '0,0,0-1' },
           { keys: [3], value: '0,0,0-2' },

--- a/src/tile.test.js
+++ b/src/tile.test.js
@@ -412,6 +412,32 @@ describe('Tile', () => {
       })
 
       it('handles empty selectors', async () => {
+        const selector = {}
+        const tile = new Tile({
+          ...defaults,
+          loader: jest.fn().mockImplementation((chunk, cb) =>
+            cb(
+              null, // error
+              ndarray([1, 2, 3, 4], [4, 1, 1])
+            )
+          ),
+          shape: [4, 1, 1],
+          chunks: [4, 1, 1],
+          dimensions: ['band', 'y', 'x'],
+          coordinates: { band: ['a', 'b', 'c', 'd'] },
+        })
+
+        await tile.loadChunks([[0, 0, 0]])
+
+        expect(tile.getPointValues({ selector, point: [0, 0] })).toEqual([
+          { keys: ['a'], value: 1 },
+          { keys: ['b'], value: 2 },
+          { keys: ['c'], value: 3 },
+          { keys: ['d'], value: 4 },
+        ])
+      })
+
+      it('handles empty selectors over multiple chunks', async () => {
         const tile = new Tile(defaults)
 
         // Load 1st chunk

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -344,20 +344,12 @@ export const createTiles = (regl, opts) => {
       })
     }
 
-    this.queryRegion = async (region, selectData = 'default') => {
+    this.queryRegion = async (region, customSelector) => {
       await this.initialized
 
       const tiles = getTilesOfRegion(region, this.level)
 
-      let selector
-      if (selectData === 'default') {
-        selector = this.selector
-      } else if (selectData === 'all') {
-        selector = {}
-      } else {
-        selector = selectData
-      }
-
+      const selector = customSelector || this.selector
       await Promise.all(
         tiles.map((key) => {
           const tileIndex = keyToTile(key)

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -344,12 +344,11 @@ export const createTiles = (regl, opts) => {
       })
     }
 
-    this.queryRegion = async (region, customSelector) => {
+    this.queryRegion = async (region, selector) => {
       await this.initialized
 
       const tiles = getTilesOfRegion(region, this.level)
 
-      const selector = customSelector || this.selector
       await Promise.all(
         tiles.map((key) => {
           const tileIndex = keyToTile(key)
@@ -370,7 +369,10 @@ export const createTiles = (regl, opts) => {
       let results,
         lat = [],
         lon = []
-      if (this.ndim > 2) {
+      const resultDim =
+        this.ndim -
+        Object.keys(selector).filter((k) => !Array.isArray(selector[k])).length
+      if (resultDim > 2) {
         results = {}
       } else {
         results = []
@@ -404,7 +406,11 @@ export const createTiles = (regl, opts) => {
                 })
 
                 valuesToSet.forEach(({ keys, value }) => {
-                  setObjectValues(results, keys, value)
+                  if (keys.length > 0) {
+                    setObjectValues(results, keys, value)
+                  } else {
+                    results.push(value)
+                  }
                 })
               } else {
                 results.push(data.get(j, i))

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -17,7 +17,6 @@ import {
   getTilesOfRegion,
   getPyramidMetadata,
   getBands,
-  getValuesToSet,
   setObjectValues,
   getChunks,
 } from './utils'
@@ -404,13 +403,7 @@ export const createTiles = (regl, opts) => {
               lat.push(pointCoords[1])
 
               if (this.ndim > 2) {
-                const valuesToSet = getValuesToSet(
-                  this.tiles[key].getData(),
-                  i,
-                  j,
-                  this.dimensions,
-                  this.coordinates
-                )
+                const valuesToSet = this.tiles[key].getData({ x: i, y: j })
 
                 valuesToSet.forEach(({ keys, value }) => {
                   setObjectValues(results, keys, value)

--- a/src/utils.js
+++ b/src/utils.js
@@ -335,49 +335,6 @@ export const setObjectValues = (obj, keys, value) => {
   return obj
 }
 
-/**
- * Returns all `value`s and identifying `keys` from iterating over the dimensions of `data` at specified x,y location
- * @param {ndarray} data
- * @param {number} x coordinate at which to lookup values
- * @param {number} y coordinate at which to lookup values
- * @param {Array<string>} dimensions to iterate over
- * @param {{[dimension]: Array<any>}} coordinate names to use for `keys`
- * @returns Array of containing `keys: Array<string>` and `value: any` (value of `data` corresponding to `keys`)
- */
-export const getValuesToSet = (data, x, y, dimensions, coordinates) => {
-  let keys = [[]]
-  let indexes = [[]]
-  dimensions.forEach((dimension) => {
-    if (dimension === 'x') {
-      // only update update indexes used for getting values
-      indexes = indexes.map((prevIndexes) => [...prevIndexes, x])
-    } else if (dimension === 'y') {
-      // only update update indexes used for getting values
-      indexes = indexes.map((prevIndexes) => [...prevIndexes, y])
-    } else {
-      const values = coordinates[dimension]
-      const updatedKeys = []
-      const updatedIndexes = []
-      values.forEach((value, i) => {
-        keys.forEach((prevKeys, j) => {
-          updatedKeys.push([...prevKeys, value])
-
-          const prevIndexes = indexes[j]
-          updatedIndexes.push([...prevIndexes, i])
-        })
-      })
-
-      keys = updatedKeys
-      indexes = updatedIndexes
-    }
-  })
-
-  return keys.map((key, i) => ({
-    keys: key,
-    value: data.get(...indexes[i]),
-  }))
-}
-
 export const getSelectorHash = (selector) => {
   return JSON.stringify(selector)
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -372,7 +372,12 @@ export const getChunks = (
         .map((_, j) => j)
     }
 
-    return indices.map((index) => Math.floor(index / chunkSize))
+    return (
+      indices
+        .map((index) => Math.floor(index / chunkSize))
+        // Filter out repeated instances of indices
+        .filter((v, i, a) => a.indexOf(v) === i)
+    )
   })
 
   let result = [[]]


### PR DESCRIPTION
This PR updates the logic used to combine chunk data into a single, nested object on region query.

Currently, we are using `ndarray` to create a partially-filled dataset of the complete data array dimensions. For large datasets where tiles must be broken up over many chunks, this is incredibly expensive and will crash the page. To avoid doing this, the logic that formerly consumed the `ndarray` instance has been moved into a new `Tile.getPointValues` method, which accepts an `x, y` `position` and returns pairs of `coordinate` "keys" and values associated with those coordinates at the specified `position`.