### PR TITLE
Clear `region` when `RegionPicker` is unmounted

### DIFF
--- a/src/region/region-picker/index.js
+++ b/src/region/region-picker/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from 'react'
+import React, { useState, useRef, useCallback, useEffect } from 'react'
 import CirclePicker from './circle-picker'
 import { UPDATE_STATS_ON_DRAG } from './constants'
 import { distance } from '@turf/turf'
@@ -36,6 +36,13 @@ function RegionPicker({
   const { setRegion } = useRegionContext()
 
   const [center, setCenter] = useState(initialCenter.current)
+
+  useEffect(() => {
+    return () => {
+      // Clear region when unmounted
+      setRegion(null)
+    }
+  }, [])
 
   const handleCircle = useCallback((circle) => {
     if (!circle) return


### PR DESCRIPTION
This PR updates `RegionPicker` to clear the `region` when unmounted. This prevents unnecessary [calls to `queryRegion`](https://github.com/carbonplan/maps/blob/07cdb2658569e21d64c680eeb8a784ab51d7ef39/src/raster.js#L95) when the `RegionPicker` is no longer active. In practice, these extra calls meant that the performance costs of fetching new tiles that we accept when the `RegionPicker` _is open_ were also surfacing _after it had been closed_.