### PR TITLE
Properly track tile loading state per chunk

### DIFF
--- a/src/tiles.js
+++ b/src/tiles.js
@@ -316,9 +316,6 @@ export const createTiles = (regl, opts) => {
                   return
                 }
 
-                if (tile.key === '0,0,1') {
-                }
-
                 if (tile.isLoadingChunks(chunks)) {
                   // If tile is already loading all chunks, wait for ready state and populate buffers if possible
                   tile.ready().then(() => {

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -316,8 +316,11 @@ export const createTiles = (regl, opts) => {
                   return
                 }
 
-                if (tile.loading) {
-                  // If tile is already loading, wait for ready state and populate buffers if possible
+                if (tile.key === '0,0,1') {
+                }
+
+                if (tile.isLoadingChunks(chunks)) {
+                  // If tile is already loading all chunks, wait for ready state and populate buffers if possible
                   tile.ready().then(() => {
                     if (
                       tile.hasLoadedChunks(chunks) &&
@@ -337,7 +340,7 @@ export const createTiles = (regl, opts) => {
                     this.invalidate()
                     resolve(false)
                   } else {
-                    // Set loading=true if any tile data is not yet fetched
+                    // Set loading=true if any tile chunk is not yet loaded
                     this.setLoading(true)
                     tile
                       .populateBuffers(chunks, this.selector)
@@ -355,7 +358,9 @@ export const createTiles = (regl, opts) => {
           invalidateRegion()
         }
 
-        if (Object.keys(this.active).every((key) => !this.tiles[key].loading)) {
+        if (
+          Object.keys(this.active).every((key) => !this.tiles[key].isLoading())
+        ) {
           // Set loading=false only when all active tiles are done loading
           this.setLoading(false)
         }


### PR DESCRIPTION
This PR removes the global `tile.loading` state and instead stores a `_loading` object to track which chunks are being loaded. This more explicit tracking:
- allows `tiles` to explicitly check whether relevant chunks are being loaded instead of assuming that `loading=true` indicates this
- prevents the completion of one chunk request of many from falsely setting the global `loading` state to `false`