### PR TITLE
Refactor setLoading

### DIFF
--- a/src/loading/context.js
+++ b/src/loading/context.js
@@ -20,7 +20,7 @@ export const useSetLoading = () => {
 
   useEffect(() => {
     return () => {
-      dispatch({ ids, type: 'unset all' })
+      dispatch({ ids, type: 'clear all' })
     }
   }, [])
 
@@ -31,26 +31,27 @@ export const useSetLoading = () => {
       return prev
     })
     dispatch({ id, type: 'set' })
-    const unsetLoading = () => {
-      dispatch({ id, type: 'unset' })
-      setIds((prev) => {
-        prev.delete(id)
-        return prev
-      })
-    }
-    return unsetLoading
+    return id
   }, [])
 
-  return { setLoading, loading: ids.size > 0 }
+  const clearLoading = useCallback((id) => {
+    dispatch({ id, type: 'clear' })
+    setIds((prev) => {
+      prev.delete(id)
+      return prev
+    })
+  }, [])
+
+  return { setLoading, clearLoading, loading: ids.size > 0 }
 }
 
 const reducer = (state, action) => {
   switch (action.type) {
     case 'set':
       return [...state, action.id]
-    case 'unset':
+    case 'clear':
       return state.filter((el) => el !== action.id)
-    case 'unset all':
+    case 'clear all':
       return state.filter((el) => !action.ids.has(el))
     default:
       throw new Error(`Unexpected action: ${action.type}`)

--- a/src/loading/loading-updater.js
+++ b/src/loading/loading-updater.js
@@ -3,12 +3,11 @@ import React, { useEffect } from 'react'
 import { useLoadingContext } from './context'
 
 export const LoadingUpdater = ({ setLoading }) => {
-  const { values } = useLoadingContext()
-  const loading = Object.keys(values).some((key) => values[key])
+  const { value } = useLoadingContext()
 
   useEffect(() => {
-    setLoading(loading)
-  }, [loading])
+    setLoading(value)
+  }, [value])
 
   return null
 }

--- a/src/raster.js
+++ b/src/raster.js
@@ -24,7 +24,7 @@ const Raster = (props) => {
   const { regl } = useRegl()
   const { map } = useMapbox()
   const { region } = useRegion()
-  const { setLoading } = useSetLoading()
+  const { setLoading, loading } = useSetLoading()
   const tiles = useRef()
   const camera = useRef()
   const lastQueried = useRef()
@@ -48,10 +48,7 @@ const Raster = (props) => {
   useEffect(() => {
     tiles.current = createTiles(regl, {
       ...props,
-      setLoading: (value) => {
-        props.setLoading && props.setLoading(value)
-        setLoading(value)
-      },
+      setLoading,
       invalidate: () => {
         map.triggerRepaint()
       },
@@ -60,6 +57,12 @@ const Raster = (props) => {
       },
     })
   }, [])
+
+  useEffect(() => {
+    if (props.setLoading) {
+      props.setLoading(loading)
+    }
+  }, [!!props.setLoading, loading])
 
   useEffect(() => {
     const callback = () => {

--- a/src/raster.js
+++ b/src/raster.js
@@ -24,7 +24,7 @@ const Raster = (props) => {
   const { regl } = useRegl()
   const { map } = useMapbox()
   const { region } = useRegion()
-  const { setLoading, loading } = useSetLoading()
+  const { setLoading, clearLoading, loading } = useSetLoading()
   const tiles = useRef()
   const camera = useRef()
   const lastQueried = useRef()
@@ -49,6 +49,7 @@ const Raster = (props) => {
     tiles.current = createTiles(regl, {
       ...props,
       setLoading,
+      clearLoading,
       invalidate: () => {
         map.triggerRepaint()
       },


### PR DESCRIPTION
This PR updates the `LoadingContext` and `useSetLoading` hook to accommodate tracking _multiple loading states per caller_. Specifically, this allows a single `Raster` layer to track an arbitrary number of in-progress requests and measure `loading` explicitly based on whether any loading states have yet to be cleared.

This makes it trivial to invoke `setLoading` for initial metadata and coordinate requests (resolves #40)