### PR TITLE
Tweak loading interface

### DIFF
--- a/src/loading/context.js
+++ b/src/loading/context.js
@@ -4,66 +4,125 @@ import React, {
   useContext,
   useEffect,
   useReducer,
+  useRef,
   useState,
 } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
 const LoadingContext = createContext({})
 
-export const useLoadingContext = () => {
-  return useContext(LoadingContext)
-}
-
 export const useSetLoading = () => {
-  const { dispatch } = useLoadingContext()
-  const [ids, setIds] = useState(new Set())
+  const loadingId = useRef(uuidv4())
+  const loading = useRef(false)
+  const { dispatch } = useContext(LoadingContext)
+  const [initializingIds, setInitializingIds] = useState(new Set())
+  const [fetchingIds, setFetchingIds] = useState(new Set())
 
   useEffect(() => {
     return () => {
-      dispatch({ ids, type: 'clear all' })
+      dispatch({ ids: initializingIds, type: 'clear all', key: 'initializing' })
+      dispatch({ ids: fetchingIds, type: 'clear all', key: 'fetching' })
+      dispatch({ id: loadingId.current, type: 'clear', key: 'loading' })
     }
   }, [])
 
-  const setLoading = useCallback(() => {
+  const setLoading = useCallback((key = 'fetching') => {
     const id = uuidv4()
-    setIds((prev) => {
+    const setter = key === 'initializing' ? setInitializingIds : setFetchingIds
+    setter((prev) => {
       prev.add(id)
       return prev
     })
-    dispatch({ id, type: 'set' })
+
+    if (!loading.current) {
+      dispatch({ id: loadingId.current, type: 'set', key: 'loading' })
+      loading.current = true
+    }
+    dispatch({ id, type: 'set', key })
     return id
   }, [])
 
   const clearLoading = useCallback((id) => {
-    dispatch({ id, type: 'clear' })
-    setIds((prev) => {
-      prev.delete(id)
-      return prev
+    setInitializingIds((prevInitializing) => {
+      if (prevInitializing.has(id)) {
+        dispatch({ id, type: 'clear', key: 'initializing' })
+        prevInitializing.delete(id)
+      }
+      setFetchingIds((prevFetching) => {
+        if (prevFetching.has(id)) {
+          dispatch({ id, type: 'clear', key: 'fetching' })
+          prevFetching.delete(id)
+          if (
+            loading.current &&
+            prevInitializing.size === 0 &&
+            prevFetching.size === 0
+          ) {
+            dispatch({ id: loadingId.current, type: 'clear', key: 'loading' })
+            loading.current = false
+          }
+        }
+        return prevFetching
+      })
+      return prevInitializing
     })
   }, [])
 
-  return { setLoading, clearLoading, loading: ids.size > 0 }
+  return {
+    setLoading,
+    clearLoading,
+    loading: loading.current,
+    initializing: initializingIds.size > 0,
+    fetching: fetchingIds.size > 0,
+  }
 }
 
 const reducer = (state, action) => {
   switch (action.type) {
     case 'set':
-      return [...state, action.id]
+      return {
+        ...state,
+        [action.key]: [...state[action.key], action.id],
+      }
     case 'clear':
-      return state.filter((el) => el !== action.id)
+      return {
+        ...state,
+        [action.key]: state[action.key].filter((el) => el !== action.id),
+      }
     case 'clear all':
-      return state.filter((el) => !action.ids.has(el))
+      return {
+        ...state,
+        [action.key]: state[action.key].filter((el) => !action.ids.has(el)),
+      }
     default:
       throw new Error(`Unexpected action: ${action.type}`)
   }
 }
 
 export const LoadingProvider = ({ children }) => {
-  const [state, dispatch] = useReducer(reducer, [])
+  const [state, dispatch] = useReducer(reducer, {
+    loading: [],
+    initializing: [],
+    fetching: [],
+  })
 
   return (
-    <LoadingContext.Provider value={{ value: state.length > 0, dispatch }}>
+    <LoadingContext.Provider
+      value={{
+        ...state,
+        dispatch,
+      }}
+    >
       {children}
     </LoadingContext.Provider>
   )
+}
+
+export const useLoadingContext = () => {
+  const { loading, initializing, fetching } = useContext(LoadingContext)
+
+  return {
+    loading: loading.length > 0,
+    initializing: initializing.length > 0,
+    fetching: fetching.length > 0,
+  }
 }

--- a/src/loading/context.js
+++ b/src/loading/context.js
@@ -42,29 +42,35 @@ export const useSetLoading = () => {
     return id
   }, [])
 
-  const clearLoading = useCallback((id) => {
-    setInitializingIds((prevInitializing) => {
-      if (prevInitializing.has(id)) {
-        dispatch({ id, type: 'clear', key: 'initializing' })
-        prevInitializing.delete(id)
-      }
-      setFetchingIds((prevFetching) => {
-        if (prevFetching.has(id)) {
-          dispatch({ id, type: 'clear', key: 'fetching' })
-          prevFetching.delete(id)
-          if (
-            loading.current &&
-            prevInitializing.size === 0 &&
-            prevFetching.size === 0
-          ) {
-            dispatch({ id: loadingId.current, type: 'clear', key: 'loading' })
-            loading.current = false
-          }
+  const clearLoading = useCallback((id, { forceClear } = {}) => {
+    if (id) {
+      setInitializingIds((prevInitializing) => {
+        if (prevInitializing.has(id)) {
+          dispatch({ id, type: 'clear', key: 'initializing' })
+          prevInitializing.delete(id)
         }
-        return prevFetching
+        setFetchingIds((prevFetching) => {
+          if (prevFetching.has(id)) {
+            dispatch({ id, type: 'clear', key: 'fetching' })
+            prevFetching.delete(id)
+            if (
+              loading.current &&
+              prevInitializing.size === 0 &&
+              prevFetching.size === 0
+            ) {
+              dispatch({ id: loadingId.current, type: 'clear', key: 'loading' })
+              loading.current = false
+            }
+          }
+          return prevFetching
+        })
+        return prevInitializing
       })
-      return prevInitializing
-    })
+    }
+    if (forceClear && loading.current) {
+      dispatch({ id: loadingId.current, type: 'clear', key: 'loading' })
+      loading.current = false
+    }
   }, [])
 
   return {

--- a/src/loading/loading-updater.js
+++ b/src/loading/loading-updater.js
@@ -4,10 +4,10 @@ import { useLoadingContext } from './context'
 
 export const LoadingUpdater = ({
   setLoading,
-  setInitializing,
-  setFetching,
+  setMetadataLoading,
+  setChunkLoading,
 }) => {
-  const { loading, initializing, fetching } = useLoadingContext()
+  const { loading, metadataLoading, chunkLoading } = useLoadingContext()
 
   useEffect(() => {
     if (setLoading) {
@@ -16,16 +16,16 @@ export const LoadingUpdater = ({
   }, [!!setLoading, loading])
 
   useEffect(() => {
-    if (setInitializing) {
-      setInitializing(initializing)
+    if (setMetadataLoading) {
+      setMetadataLoading(metadataLoading)
     }
-  }, [!!setInitializing, initializing])
+  }, [!!setMetadataLoading, metadataLoading])
 
   useEffect(() => {
-    if (setFetching) {
-      setFetching(fetching)
+    if (setChunkLoading) {
+      setChunkLoading(chunkLoading)
     }
-  }, [!!setFetching, fetching])
+  }, [!!setChunkLoading, chunkLoading])
 
   return null
 }

--- a/src/loading/loading-updater.js
+++ b/src/loading/loading-updater.js
@@ -1,13 +1,31 @@
-import React, { useEffect } from 'react'
+import { useEffect } from 'react'
 
 import { useLoadingContext } from './context'
 
-export const LoadingUpdater = ({ setLoading }) => {
-  const { value } = useLoadingContext()
+export const LoadingUpdater = ({
+  setLoading,
+  setInitializing,
+  setFetching,
+}) => {
+  const { loading, initializing, fetching } = useLoadingContext()
 
   useEffect(() => {
-    setLoading(value)
-  }, [value])
+    if (setLoading) {
+      setLoading(loading)
+    }
+  }, [!!setLoading, loading])
+
+  useEffect(() => {
+    if (setInitializing) {
+      setInitializing(initializing)
+    }
+  }, [!!setInitializing, initializing])
+
+  useEffect(() => {
+    if (setFetching) {
+      setFetching(fetching)
+    }
+  }, [!!setFetching, fetching])
 
   return null
 }

--- a/src/map.js
+++ b/src/map.js
@@ -19,8 +19,8 @@ const Map = ({
   glyphs,
   children,
   setLoading,
-  setInitializing,
-  setFetching,
+  setMetadataLoading,
+  setChunkLoading,
 }) => {
   return (
     <div
@@ -56,8 +56,8 @@ const Map = ({
           <LoadingProvider>
             <LoadingUpdater
               setLoading={setLoading}
-              setInitializing={setInitializing}
-              setFetching={setFetching}
+              setMetadataLoading={setMetadataLoading}
+              setChunkLoading={setChunkLoading}
             />
             <RegionProvider>{children}</RegionProvider>
           </LoadingProvider>

--- a/src/map.js
+++ b/src/map.js
@@ -18,8 +18,11 @@ const Map = ({
   extensions,
   glyphs,
   children,
+  /** Tracks *any* pending requests made by containing `Raster` layers */
   setLoading,
+  /** Tracks any metadata and coordinate requests made on initialization by containing `Raster` layers */
   setMetadataLoading,
+  /** Tracks any requests of new chunks by containing `Raster` layers */
   setChunkLoading,
 }) => {
   return (

--- a/src/map.js
+++ b/src/map.js
@@ -19,6 +19,8 @@ const Map = ({
   glyphs,
   children,
   setLoading,
+  setInitializing,
+  setFetching,
 }) => {
   return (
     <div
@@ -52,7 +54,11 @@ const Map = ({
           }}
         >
           <LoadingProvider>
-            {setLoading && <LoadingUpdater setLoading={setLoading} />}
+            <LoadingUpdater
+              setLoading={setLoading}
+              setInitializing={setInitializing}
+              setFetching={setFetching}
+            />
             <RegionProvider>{children}</RegionProvider>
           </LoadingProvider>
         </Regl>

--- a/src/raster.js
+++ b/src/raster.js
@@ -24,7 +24,8 @@ const Raster = (props) => {
   const { regl } = useRegl()
   const { map } = useMapbox()
   const { region } = useRegion()
-  const { setLoading, clearLoading, loading } = useSetLoading()
+  const { setLoading, clearLoading, loading, fetching, initializing } =
+    useSetLoading()
   const tiles = useRef()
   const camera = useRef()
   const lastQueried = useRef()
@@ -64,6 +65,16 @@ const Raster = (props) => {
       props.setLoading(loading)
     }
   }, [!!props.setLoading, loading])
+  useEffect(() => {
+    if (props.setInitializing) {
+      props.setInitializing(initializing)
+    }
+  }, [!!props.setInitializing, initializing])
+  useEffect(() => {
+    if (props.setFetching) {
+      props.setFetching(fetching)
+    }
+  }, [!!props.setFetching, fetching])
 
   useEffect(() => {
     const callback = () => {

--- a/src/raster.js
+++ b/src/raster.js
@@ -24,7 +24,7 @@ const Raster = (props) => {
   const { regl } = useRegl()
   const { map } = useMapbox()
   const { region } = useRegion()
-  const { setLoading, clearLoading, loading, fetching, initializing } =
+  const { setLoading, clearLoading, loading, chunkLoading, metadataLoading } =
     useSetLoading()
   const tiles = useRef()
   const camera = useRef()
@@ -66,15 +66,15 @@ const Raster = (props) => {
     }
   }, [!!props.setLoading, loading])
   useEffect(() => {
-    if (props.setInitializing) {
-      props.setInitializing(initializing)
+    if (props.setMetadataLoading) {
+      props.setMetadataLoading(metadataLoading)
     }
-  }, [!!props.setInitializing, initializing])
+  }, [!!props.setMetadataLoading, metadataLoading])
   useEffect(() => {
-    if (props.setFetching) {
-      props.setFetching(fetching)
+    if (props.setChunkLoading) {
+      props.setChunkLoading(chunkLoading)
     }
-  }, [!!props.setFetching, fetching])
+  }, [!!props.setChunkLoading, chunkLoading])
 
   useEffect(() => {
     const callback = () => {

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -289,6 +289,10 @@ export const createTiles = (regl, opts) => {
         size: this.size,
       })
 
+      if (this.size && Object.keys(this.active).length === 0) {
+        this.clearLoading(null, { forceClear: true })
+      }
+
       Promise.all(
         Object.keys(this.active).map(
           (key) =>

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -99,7 +99,7 @@ export const createTiles = (regl, opts) => {
     customUniforms.forEach((k) => (uniforms[k] = regl.this(k)))
 
     this.initialized = new Promise((resolve) => {
-      const loadingID = this.setLoading(true)
+      const loadingID = this.setLoading('initializing')
       zarr().openGroup(source, (err, loaders, metadata) => {
         const { levels, maxZoom, tileSize } = getPyramidMetadata(metadata)
         this.maxZoom = maxZoom
@@ -314,7 +314,7 @@ export const createTiles = (regl, opts) => {
 
                 if (tile.isLoadingChunks(chunks)) {
                   // If tile is already loading all chunks, wait for ready state and populate buffers if possible
-                  const loadingID = this.setLoading(true)
+                  const loadingID = this.setLoading()
                   tile.ready().then(() => {
                     if (
                       tile.hasLoadedChunks(chunks) &&
@@ -335,7 +335,7 @@ export const createTiles = (regl, opts) => {
                     this.invalidate()
                     resolve(false)
                   } else {
-                    const loadingID = this.setLoading(true)
+                    const loadingID = this.setLoading()
                     tile
                       .populateBuffers(chunks, this.selector)
                       .then((dataUpdated) => {

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -99,7 +99,7 @@ export const createTiles = (regl, opts) => {
     customUniforms.forEach((k) => (uniforms[k] = regl.this(k)))
 
     this.initialized = new Promise((resolve) => {
-      const loadingID = this.setLoading('initializing')
+      const loadingID = this.setLoading('metadata')
       zarr().openGroup(source, (err, loaders, metadata) => {
         const { levels, maxZoom, tileSize } = getPyramidMetadata(metadata)
         this.maxZoom = maxZoom
@@ -318,7 +318,7 @@ export const createTiles = (regl, opts) => {
 
                 if (tile.isLoadingChunks(chunks)) {
                   // If tile is already loading all chunks, wait for ready state and populate buffers if possible
-                  const loadingID = this.setLoading()
+                  const loadingID = this.setLoading('chunk')
                   tile.ready().then(() => {
                     if (
                       tile.hasLoadedChunks(chunks) &&
@@ -339,7 +339,7 @@ export const createTiles = (regl, opts) => {
                     this.invalidate()
                     resolve(false)
                   } else {
-                    const loadingID = this.setLoading()
+                    const loadingID = this.setLoading('chunk')
                     tile
                       .populateBuffers(chunks, this.selector)
                       .then((dataUpdated) => {

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -326,7 +326,7 @@ export const createTiles = (regl, opts) => {
                     } else {
                       resolve(false)
                     }
-                    clearLoading(loadingID)
+                    this.clearLoading(loadingID)
                   })
                 } else {
                   // Otherwise, immediately kick off fetch or populate buffers.


### PR DESCRIPTION
This PR splits the single boolean loading state accessible via `setLoading` into three distinct callbacks:
- `setLoading`:
  - most comprehensive loading state, should cover most basic tracking needs
  - similar to existing callback except that `loading` will not get set to false until either first set of chunks are fetched _or_ there are no active map tiles
  - this means that `loading` should be continuously set to true from the start of the metadata fetch to the first map paint
- `setInitializing`:
  - tracks whether initial pyramid data (`zmetadata` and `coordinate` information) fetch is in progress
- `setFetching`:
  - tracks whether any non-initialization requests (e.g. tile data requests) are in-flight

**Open questions:**
- How clear are these callback names? Another option might be `setLoading`, `setInitialLoading`, and `setTileLoading` to signal the additive quality of `setLoading` (will be true whenever `setInitialLoading` returns true _or_ `setTileLoading` returns true _or_ in between). My main hesitation is that I don't think we use "tile" at all right now externally.
- It'd be nice to document these callbacks somewhere -- for now I think I may just add inline comments in `Raster` and `Map` unless there's a better place for this.