### PR TITLE
More loading state tweaks

### DIFF
--- a/src/tiles.js
+++ b/src/tiles.js
@@ -19,6 +19,7 @@ import {
   getBands,
   setObjectValues,
   getChunks,
+  getSelectorHash,
 } from './utils'
 import Tile from './tile'
 
@@ -310,6 +311,7 @@ export const createTiles = (regl, opts) => {
                   tileIndex[0],
                   tileIndex[1]
                 )
+                const initialHash = getSelectorHash(this.selector)
 
                 if (tile.hasPopulatedBuffer(this.selector)) {
                   resolve(false)
@@ -317,12 +319,10 @@ export const createTiles = (regl, opts) => {
                 }
 
                 if (tile.isLoadingChunks(chunks)) {
-                  // If tile is already loading all chunks, wait for ready state and populate buffers if possible
-                  tile.ready().then(() => {
-                    if (
-                      tile.hasLoadedChunks(chunks) &&
-                      !tile.hasPopulatedBuffer(this.selector)
-                    ) {
+                  // If tile is already loading all chunks...
+                  tile.chunksLoaded(chunks).then(() => {
+                    // ...wait for ready state and populate buffers if selector is still relevant.
+                    if (initialHash === getSelectorHash(this.selector)) {
                       tile.populateBuffersSync(this.selector)
                       this.invalidate()
                       resolve(false)


### PR DESCRIPTION
A couple additional loading state tweaks to fix bugs:
- Move some `setLoading` calls into `queryRegion` to explicitly track fetches as they're kicked off:
  - Previously, we were exclusively tracking in `updateCamera` both when fetching was kicked off (this remains) and when already loading (`tile.isLoadingChunks(chunks)` returns true) chunks fetched first from an ongoing `queryRegion`.
  - Combined with unreliable `ready()` results (see below), this could leave map hanging in an invalid `loading` state.
  - Even when `ready()` returned then correct result, multiple calls to `updateCamera` during the time taken to load a `chunk` could create multiple entries in `LoadingContext` unnecessarily.
- Refactor `Tile` to track chunk-level ready states in `_ready` object instead of global `ready()` Promise:
  - Previously, we overwrote the `ready()` Promise whenever a new set of chunks were loaded. This meant that if chunks were rapidly requested for a single `Tile`, the wrong Promise could be `await`ed when `ready()` returned an unexpected Promise.
  - In the worse case, this meant that the `Promise` never resolved and the map was left `loading`.
- Adds an explicit check to ensure that `selector` has not become out-of-date before trying to populate buffers