### PR TITLE
Listen for changes to debug prop

### DIFF
--- a/src/mapbox.js
+++ b/src/mapbox.js
@@ -46,7 +46,6 @@ const Mapbox = ({
       })
       if (center) map.current.setCenter(center)
       if (zoom) map.current.setZoom(zoom)
-      if (debug) map.current.showTileBoundaries = true
       map.current.touchZoomRotate.disableRotation()
       map.current.touchPitch.disable()
       map.current.on('styledata', () => {
@@ -63,6 +62,10 @@ const Mapbox = ({
       }
     }
   }, [])
+
+  useEffect(() => {
+    map.current.showTileBoundaries = debug
+  }, [debug])
 
   return (
     <MapboxContext.Provider


### PR DESCRIPTION

This PR adds an additional `useEffect` to `Mapbox` that listens for changes to the `debug` prop and sets that map `showTileBoundaries` property accordingly. This enables on-the-fly changes to the `showTileBoundaries` instead of fixing to the `debug` value provided on initialization.

closes #48

![boundaries](https://user-images.githubusercontent.com/12436887/169918952-beb8f5ea-d1f0-4819-8d33-81b865704fc2.gif)
