### PR TITLE
Tweak dependencies in useEffect that triggers queryRegion

### DIFF
--- a/src/raster.js
+++ b/src/raster.js
@@ -113,8 +113,7 @@ const Raster = (props) => {
     regionOptions?.setData,
     region,
     regionDataInvalidated,
-    ...Object.values(regionOptions?.selector || {}),
-    ...Object.values(selector),
+    ...Object.values(regionOptions?.selector || selector || {}),
   ])
 
   return null


### PR DESCRIPTION
Update the `useEffect` that triggers `queryRegion` in `Raster` to only include the top-level `selector` values in the dependency array when `regionOptions.selector` is not present. This corrects the current behavior which triggers `queryRegion` when a `selector` value that only affects display is changed (e.g. when display time is updated in the CMIP6 web tool but the regional data continues to show a wider time extent, see https://github.com/carbonplan/cmip6-web/issues/57).