### PR TITLE
Update Raster to support Zarr v3 and equirectangular data

### DIFF
--- a/demo/components/region-controls.js
+++ b/demo/components/region-controls.js
@@ -3,12 +3,12 @@ import { useRecenterRegion } from '@carbonplan/maps'
 import { XCircle } from '@carbonplan/icons'
 
 const AverageDisplay = ({ band, data: { value } }) => {
-  if (!value || !value.climate) {
+  if (!value || !value.tasmax) {
     return 'loading...'
   }
 
   let result
-  const filteredData = value.climate.filter((d) => d !== 9.969209968386869e36)
+  const filteredData = value.tasmax.filter((d) => d !== 9.969209968386869e36)
   if (filteredData.length === 0) {
     result = 'no data in region'
   } else {

--- a/demo/components/region-controls.js
+++ b/demo/components/region-controls.js
@@ -3,12 +3,12 @@ import { useRecenterRegion } from '@carbonplan/maps'
 import { XCircle } from '@carbonplan/icons'
 
 const AverageDisplay = ({ band, data: { value } }) => {
-  if (!value || !value.tasmax) {
+  if (!value || !value.climate) {
     return 'loading...'
   }
 
   let result
-  const filteredData = value.tasmax.filter((d) => d !== 9.969209968386869e36)
+  const filteredData = value.climate.filter((d) => d !== 9.969209968386869e36)
   if (filteredData.length === 0) {
     result = 'no data in region'
   } else {

--- a/demo/pages/index.js
+++ b/demo/pages/index.js
@@ -6,15 +6,15 @@ import { useThemedColormap } from '@carbonplan/colormaps'
 import RegionControls from '../components/region-controls'
 import ParameterControls from '../components/parameter-controls'
 
-const bucket = 'https://storage.googleapis.com/carbonplan-maps/'
+const bucket = 'https://carbonplan-maps.s3.us-west-2.amazonaws.com/'
 
 const Index = () => {
   const { theme } = useThemeUI()
   const [display, setDisplay] = useState(true)
   const [debug, setDebug] = useState(false)
   const [opacity, setOpacity] = useState(1)
-  const [clim, setClim] = useState([221.5, 315.4])
-  const [month, setMonth] = useState(0)
+  const [clim, setClim] = useState([-20, 30])
+  const [month, setMonth] = useState(1)
   const [band, setBand] = useState('tavg')
   const [colormapName, setColormapName] = useState('warm')
   const colormap = useThemedColormap(colormapName)
@@ -42,12 +42,12 @@ const Index = () => {
         title={'@carbonplan/maps'}
       />
       <Box sx={{ position: 'absolute', top: 0, bottom: 0, width: '100%' }}>
-        <Map zoom={0} center={[0, 0]} debug={debug}>
-          {/* <Fill
+        <Map zoom={2} center={[0, 0]} debug={debug}>
+          <Fill
             color={theme.rawColors.background}
             source={bucket + 'basemaps/ocean'}
             variable={'ocean'}
-          /> */}
+          />
           <Line
             color={theme.rawColors.primary}
             source={bucket + 'basemaps/land'}
@@ -67,14 +67,10 @@ const Index = () => {
             clim={clim}
             display={display}
             opacity={opacity}
-            projection='equirectangular'
-            order={[1, -1]}
             mode={'texture'}
-            source={
-              'https://carbonplan-data-viewer.s3.amazonaws.com/demo/ScenarioMIP.CCCma.CanESM5.ssp245.r1i1p1f1.annual.GARD-SV.tasmax.pyramid.zarr'
-            }
-            variable={'tasmax'}
-            selector={{ time: month }}
+            source={bucket + 'v2/demo/4d/tavg-prec-month'}
+            variable={'climate'}
+            selector={{ month, band }}
             regionOptions={{ setData: setRegionData }}
           />
           <RegionControls

--- a/demo/pages/index.js
+++ b/demo/pages/index.js
@@ -13,8 +13,8 @@ const Index = () => {
   const [display, setDisplay] = useState(true)
   const [debug, setDebug] = useState(false)
   const [opacity, setOpacity] = useState(1)
-  const [clim, setClim] = useState([-20, 30])
-  const [month, setMonth] = useState(1)
+  const [clim, setClim] = useState([221.5, 315.4])
+  const [month, setMonth] = useState(0)
   const [band, setBand] = useState('tavg')
   const [colormapName, setColormapName] = useState('warm')
   const colormap = useThemedColormap(colormapName)
@@ -42,12 +42,12 @@ const Index = () => {
         title={'@carbonplan/maps'}
       />
       <Box sx={{ position: 'absolute', top: 0, bottom: 0, width: '100%' }}>
-        <Map zoom={2} center={[0, 0]} debug={debug}>
-          <Fill
+        <Map zoom={0} center={[0, 0]} debug={debug}>
+          {/* <Fill
             color={theme.rawColors.background}
             source={bucket + 'basemaps/ocean'}
             variable={'ocean'}
-          />
+          /> */}
           <Line
             color={theme.rawColors.primary}
             source={bucket + 'basemaps/land'}
@@ -68,9 +68,11 @@ const Index = () => {
             display={display}
             opacity={opacity}
             mode={'texture'}
-            source={bucket + 'v2/demo/4d/tavg-prec-month'}
-            variable={'climate'}
-            selector={{ month, band }}
+            source={
+              'https://carbonplan-data-viewer.s3.amazonaws.com/demo/ScenarioMIP.CCCma.CanESM5.ssp245.r1i1p1f1.annual.GARD-SV.tasmax.pyramid.zarr'
+            }
+            variable={'tasmax'}
+            selector={{ time: month }}
             regionOptions={{ setData: setRegionData }}
           />
           <RegionControls

--- a/demo/pages/index.js
+++ b/demo/pages/index.js
@@ -67,6 +67,8 @@ const Index = () => {
             clim={clim}
             display={display}
             opacity={opacity}
+            projection='equirectangular'
+            order={[1, -1]}
             mode={'texture'}
             source={
               'https://carbonplan-data-viewer.s3.amazonaws.com/demo/ScenarioMIP.CCCma.CanESM5.ssp245.r1i1p1f1.annual.GARD-SV.tasmax.pyramid.zarr'

--- a/docs/pages/maps/raster.md
+++ b/docs/pages/maps/raster.md
@@ -10,26 +10,28 @@ The `Raster` component is responsible for initializing the `mapbox-gl-js` instan
 
 <Table>
 
-| Prop               | Description                                                                                                                        | Default   |
-| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| source             | URL pointing to Zarr group                                                                                                         |           |
-| variable           | Name of array containing variable to map                                                                                           |           |
-| clim               | Array of limits for the color range, `[min, max]`                                                                                  |           |
-| colormap           | Array of vec3 arrays, each representing an RGB value to sample from                                                                |           |
-| selector           | _(N/A for 2D datasets)_ Object to index into non-spatial dimensions, maps variable name (string) to value (any) or array of values |           |
-| _optional props_   |                                                                                                                                    |           |
-| mode               | Display mode -- one of 'texture', 'grid', 'dotgrid'                                                                                | 'texture' |
-| fillValue          | Value to map to null                                                                                                               | -9999     |
-| display            | Boolean expressing whether contents should be drawn to canvas or not                                                               | `true`    |
-| opacity            | Number value for alpha value used when painting to canvas                                                                          | 1         |
-| index              | Value that, when changed, triggers a clear and redraw of the canvas                                                                | 0         |
-| regionOptions      | Object containing a `setData` callback and an optional `selector` object (falls back to `Raster`-level `selector` if not provided) |           |
-| frag               | Fragment shader to use in place of default                                                                                         |           |
-| uniforms           | Object mapping custom uniform names (string) to values (float) for use in fragment shader                                          |           |
-| setLoading         | Callback to track _any_ pending requests                                                                                           |           |
-| setMetadataLoading | Callback to track any metadata and coordinate requests made on initialization                                                      |           |
-| setChunkLoading    | Callback to track any requests of new chunks                                                                                       |           |
-| setMetadata        | Callback that is invoked with `.zmetadata` value once fetched                                                                      |           |
+| Prop               | Description                                                                                                                        | Default    |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| source             | URL pointing to Zarr group                                                                                                         |            |
+| variable           | Name of array containing variable to map                                                                                           |            |
+| clim               | Array of limits for the color range, `[min, max]`                                                                                  |            |
+| colormap           | Array of vec3 arrays, each representing an RGB value to sample from                                                                |            |
+| selector           | _(N/A for 2D datasets)_ Object to index into non-spatial dimensions, maps variable name (string) to value (any) or array of values |            |
+| _optional props_   |                                                                                                                                    |            |
+| mode               | Display mode -- one of 'texture', 'grid', 'dotgrid'                                                                                | 'texture'  |
+| version            | Version of Zarr spec source data conforms to                                                                                       | 'v2'       |
+| projection         | Projection in which source data is stored (independent of map rendering in Web Mercator)                                           | 'mercator' |
+| fillValue          | Value to map to null                                                                                                               | -9999      |
+| display            | Boolean expressing whether contents should be drawn to canvas or not                                                               | `true`     |
+| opacity            | Number value for alpha value used when painting to canvas                                                                          | 1          |
+| index              | Value that, when changed, triggers a clear and redraw of the canvas                                                                | 0          |
+| regionOptions      | Object containing a `setData` callback and an optional `selector` object (falls back to `Raster`-level `selector` if not provided) |            |
+| frag               | Fragment shader to use in place of default                                                                                         |            |
+| uniforms           | Object mapping custom uniform names (string) to values (float) for use in fragment shader                                          |            |
+| setLoading         | Callback to track _any_ pending requests                                                                                           |            |
+| setMetadataLoading | Callback to track any metadata and coordinate requests made on initialization                                                      |            |
+| setChunkLoading    | Callback to track any requests of new chunks                                                                                       |            |
+| setMetadata        | Callback that is invoked with `.zmetadata` value once fetched                                                                      |            |
 
 </Table>
 

--- a/docs/pages/maps/raster.md
+++ b/docs/pages/maps/raster.md
@@ -21,6 +21,7 @@ The `Raster` component is responsible for initializing the `mapbox-gl-js` instan
 | mode               | Display mode -- one of 'texture', 'grid', 'dotgrid'                                                                                | 'texture'  |
 | version            | Version of Zarr spec source data conforms to                                                                                       | 'v2'       |
 | projection         | Projection in which source data is stored (independent of map rendering in Web Mercator)                                           | 'mercator' |
+| order              | Array specifying whether the x, y dimensions are inverted from left -> right and top -> bottom, respectively                       | [1, 1]     |
 | fillValue          | Value to map to null                                                                                                               | -9999      |
 | display            | Boolean expressing whether contents should be drawn to canvas or not                                                               | `true`     |
 | opacity            | Number value for alpha value used when painting to canvas                                                                          | 1          |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@carbonplan/maps",
-  "version": "3.0.0-develop.4",
+  "version": "3.0.0-develop.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@carbonplan/maps",
-      "version": "3.0.0-develop.4",
+      "version": "3.0.0-develop.5",
       "license": "MIT",
       "dependencies": {
         "@turf/turf": "^6.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "regl": "^2.1.0",
         "uuid": "^8.3.2",
         "xhr-request": "^1.1.0",
-        "zarr-js": "^2.2.0"
+        "zarr-js": "^3.1.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",
@@ -6043,6 +6043,11 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw=="
+    },
     "node_modules/figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -9484,11 +9489,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -11954,16 +11954,16 @@
       }
     },
     "node_modules/zarr-js": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-2.2.0.tgz",
-      "integrity": "sha512-xjUuti2LLw+1TDQEe1m9HTeP/vMJkPwZPC/gmbP5xHbQIk6jXt0xflBoPYA/MN51Jc2r0MJFsbuBrpvgheQ6hg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-3.1.0.tgz",
+      "integrity": "sha512-7c4R3P8nuKLCNDTU2twI8JmgLyncAON5oQlFnYGIiGohskoXV497SFf0lqeX44kcaBrhD9b64h4OspyKzRAZ6g==",
       "dependencies": {
         "async": "^2.6.2",
         "cartesian-product": "^2.1.2",
+        "fflate": "^0.7.3",
         "ndarray": "^1.0.18",
         "ndarray-ops": "^1.2.2",
-        "ndarray-scratch": "^1.2.0",
-        "pako": "^1.0.10"
+        "ndarray-scratch": "^1.2.0"
       }
     }
   },
@@ -16544,6 +16544,11 @@
         "bser": "2.1.1"
       }
     },
+    "fflate": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+      "integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw=="
+    },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -19159,11 +19164,6 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
-    "pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -21015,16 +21015,16 @@
       "dev": true
     },
     "zarr-js": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-2.2.0.tgz",
-      "integrity": "sha512-xjUuti2LLw+1TDQEe1m9HTeP/vMJkPwZPC/gmbP5xHbQIk6jXt0xflBoPYA/MN51Jc2r0MJFsbuBrpvgheQ6hg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-3.1.0.tgz",
+      "integrity": "sha512-7c4R3P8nuKLCNDTU2twI8JmgLyncAON5oQlFnYGIiGohskoXV497SFf0lqeX44kcaBrhD9b64h4OspyKzRAZ6g==",
       "requires": {
         "async": "^2.6.2",
         "cartesian-product": "^2.1.2",
+        "fflate": "^0.7.3",
         "ndarray": "^1.0.18",
         "ndarray-ops": "^1.2.2",
-        "ndarray-scratch": "^1.2.0",
-        "pako": "^1.0.10"
+        "ndarray-scratch": "^1.2.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "regl": "^2.1.0",
         "uuid": "^8.3.2",
         "xhr-request": "^1.1.0",
-        "zarr-js": "^3.2.0"
+        "zarr-js": "^3.3.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",
@@ -11954,9 +11954,9 @@
       }
     },
     "node_modules/zarr-js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-3.2.0.tgz",
-      "integrity": "sha512-AikXwsj6b9PaQ1jEZr8BNPaZ8KoMqt1N49xhw/L8H92UoPeQu9eQv/hYd5RaxMxb6d4Yly7RBO3PIV8TRcp8ng==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-3.3.0.tgz",
+      "integrity": "sha512-zd6owywyeq6rSPyjBGYx9rCK1B+PDiAFKcHFTSYUiTY31CxhqkhZ/UhwB+gAHNIeuiyYCGlGyWuYcgmfa43Zeg==",
       "dependencies": {
         "async": "^2.6.2",
         "cartesian-product": "^2.1.2",
@@ -21015,9 +21015,9 @@
       "dev": true
     },
     "zarr-js": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-3.2.0.tgz",
-      "integrity": "sha512-AikXwsj6b9PaQ1jEZr8BNPaZ8KoMqt1N49xhw/L8H92UoPeQu9eQv/hYd5RaxMxb6d4Yly7RBO3PIV8TRcp8ng==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-3.3.0.tgz",
+      "integrity": "sha512-zd6owywyeq6rSPyjBGYx9rCK1B+PDiAFKcHFTSYUiTY31CxhqkhZ/UhwB+gAHNIeuiyYCGlGyWuYcgmfa43Zeg==",
       "requires": {
         "async": "^2.6.2",
         "cartesian-product": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@carbonplan/maps",
-  "version": "3.0.0-develop.5",
+  "version": "3.0.0-develop.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@carbonplan/maps",
-      "version": "3.0.0-develop.5",
+      "version": "3.0.0-develop.6",
       "license": "MIT",
       "dependencies": {
         "@turf/turf": "^6.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@carbonplan/maps",
-  "version": "3.0.0-develop.3",
+  "version": "3.0.0-develop.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@carbonplan/maps",
-      "version": "3.0.0-develop.3",
+      "version": "3.0.0-develop.4",
       "license": "MIT",
       "dependencies": {
         "@turf/turf": "^6.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "regl": "^2.1.0",
         "uuid": "^8.3.2",
         "xhr-request": "^1.1.0",
-        "zarr-js": "^3.1.0"
+        "zarr-js": "^3.2.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.4",
@@ -11954,9 +11954,9 @@
       }
     },
     "node_modules/zarr-js": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-3.1.0.tgz",
-      "integrity": "sha512-7c4R3P8nuKLCNDTU2twI8JmgLyncAON5oQlFnYGIiGohskoXV497SFf0lqeX44kcaBrhD9b64h4OspyKzRAZ6g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-3.2.0.tgz",
+      "integrity": "sha512-AikXwsj6b9PaQ1jEZr8BNPaZ8KoMqt1N49xhw/L8H92UoPeQu9eQv/hYd5RaxMxb6d4Yly7RBO3PIV8TRcp8ng==",
       "dependencies": {
         "async": "^2.6.2",
         "cartesian-product": "^2.1.2",
@@ -21015,9 +21015,9 @@
       "dev": true
     },
     "zarr-js": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-3.1.0.tgz",
-      "integrity": "sha512-7c4R3P8nuKLCNDTU2twI8JmgLyncAON5oQlFnYGIiGohskoXV497SFf0lqeX44kcaBrhD9b64h4OspyKzRAZ6g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/zarr-js/-/zarr-js-3.2.0.tgz",
+      "integrity": "sha512-AikXwsj6b9PaQ1jEZr8BNPaZ8KoMqt1N49xhw/L8H92UoPeQu9eQv/hYd5RaxMxb6d4Yly7RBO3PIV8TRcp8ng==",
       "requires": {
         "async": "^2.6.2",
         "cartesian-product": "^2.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@carbonplan/maps",
-  "version": "3.0.0",
+  "version": "3.0.0-develop.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@carbonplan/maps",
-      "version": "3.0.0",
+      "version": "3.0.0-develop.3",
       "license": "MIT",
       "dependencies": {
         "@turf/turf": "^6.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "d3-geo": "^2.0.2",
         "d3-scale": "^2.2.2",
         "d3-selection": "^2.0.0",
+        "glsl-geo-projection": "^1.0.1",
         "mapbox-gl": "^1.13.1",
         "ndarray": "^1.0.19",
         "regl": "^2.1.0",
@@ -6328,6 +6329,11 @@
       "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
       "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
       "dev": true
+    },
+    "node_modules/glsl-geo-projection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glsl-geo-projection/-/glsl-geo-projection-1.0.1.tgz",
+      "integrity": "sha512-6r118GFi+q5lzF3N0Jevv15eveVwLeIqqFe4XRnnYnU/Y/Bp38XpySQaGBO0EzXNhzesUik7c2uSEuYUwa+ogw=="
     },
     "node_modules/graceful-fs": {
       "version": "4.2.8",
@@ -16760,6 +16766,11 @@
       "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
       "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
       "dev": true
+    },
+    "glsl-geo-projection": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glsl-geo-projection/-/glsl-geo-projection-1.0.1.tgz",
+      "integrity": "sha512-6r118GFi+q5lzF3N0Jevv15eveVwLeIqqFe4XRnnYnU/Y/Bp38XpySQaGBO0EzXNhzesUik7c2uSEuYUwa+ogw=="
     },
     "graceful-fs": {
       "version": "4.2.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@carbonplan/maps",
-  "version": "3.0.0-develop.6",
+  "version": "3.0.0-develop.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@carbonplan/maps",
-      "version": "3.0.0-develop.6",
+      "version": "3.0.0-develop.7",
       "license": "MIT",
       "dependencies": {
         "@turf/turf": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbonplan/maps",
-  "version": "3.0.0-develop.4",
+  "version": "3.0.0-develop.5",
   "description": "interactive data-driven web maps",
   "main": "dst/index.js",
   "module": "dst/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "regl": "^2.1.0",
     "uuid": "^8.3.2",
     "xhr-request": "^1.1.0",
-    "zarr-js": "^2.2.0"
+    "zarr-js": "^3.1.0"
   },
   "peerDependencies": {
     "react": ">=18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbonplan/maps",
-  "version": "3.0.0",
+  "version": "3.0.0-develop.3",
   "description": "interactive data-driven web maps",
   "main": "dst/index.js",
   "module": "dst/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "d3-geo": "^2.0.2",
     "d3-scale": "^2.2.2",
     "d3-selection": "^2.0.0",
+    "glsl-geo-projection": "^1.0.1",
     "mapbox-gl": "^1.13.1",
     "ndarray": "^1.0.19",
     "regl": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbonplan/maps",
-  "version": "3.0.0-develop.3",
+  "version": "3.0.0-develop.4",
   "description": "interactive data-driven web maps",
   "main": "dst/index.js",
   "module": "dst/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbonplan/maps",
-  "version": "3.0.0-develop.5",
+  "version": "3.0.0-develop.6",
   "description": "interactive data-driven web maps",
   "main": "dst/index.js",
   "module": "dst/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "regl": "^2.1.0",
     "uuid": "^8.3.2",
     "xhr-request": "^1.1.0",
-    "zarr-js": "^3.2.0"
+    "zarr-js": "^3.3.0"
   },
   "peerDependencies": {
     "react": ">=18",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "regl": "^2.1.0",
     "uuid": "^8.3.2",
     "xhr-request": "^1.1.0",
-    "zarr-js": "^3.1.0"
+    "zarr-js": "^3.2.0"
   },
   "peerDependencies": {
     "react": ">=18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbonplan/maps",
-  "version": "3.0.0-develop.6",
+  "version": "3.0.0-develop.7",
   "description": "interactive data-driven web maps",
   "main": "dst/index.js",
   "module": "dst/index.esm.js",

--- a/src/initialize-store.js
+++ b/src/initialize-store.js
@@ -1,0 +1,123 @@
+import zarr from 'zarr-js'
+
+import { getPyramidMetadata } from './utils'
+
+const initializeStore = async (source, version, variable, coordinateKeys) => {
+  let metadata
+  let loaders
+  let dimensions
+  let shape
+  let chunks
+  let fill_value
+  let dtype
+  let levels, maxZoom, tileSize
+  const coordinates = {}
+  switch (version) {
+    case 'v2':
+      await new Promise((resolve) =>
+        zarr(window.fetch, version).openGroup(source, (err, l, m) => {
+          loaders = l
+          metadata = m
+          resolve()
+        })
+      )
+      ;({ levels, maxZoom, tileSize } = getPyramidMetadata(
+        metadata.metadata['.zattrs'].multiscales
+      ))
+
+      const zattrs = metadata.metadata[`${levels[0]}/${variable}/.zattrs`]
+      const zarray = metadata.metadata[`${levels[0]}/${variable}/.zarray`]
+      dimensions = zattrs['_ARRAY_DIMENSIONS']
+      shape = zarray.shape
+      chunks = zarray.chunks
+      fill_value = zarray.fill_value
+      dtype = zarray.dtype
+
+      await Promise.all(
+        coordinateKeys.map(
+          (key) =>
+            new Promise((resolve) => {
+              loaders[`${levels[0]}/${key}`]([0], (err, chunk) => {
+                coordinates[key] = Array.from(chunk.data)
+                resolve()
+              })
+            })
+        )
+      )
+
+      break
+    case 'v3':
+      metadata = await fetch(`${source}/zarr.json`).then((res) => res.json())
+      ;({ levels, maxZoom, tileSize } = getPyramidMetadata(
+        metadata.attributes.multiscales
+      ))
+
+      const arrayMetadata = await fetch(
+        `${source}/${levels[0]}/${variable}/zarr.json`
+      ).then((res) => res.json())
+
+      dimensions = arrayMetadata.attributes['_ARRAY_DIMENSIONS']
+      shape = arrayMetadata.shape
+      const isSharded = arrayMetadata.codecs[0].name == 'sharding_indexed'
+      chunks = isSharded
+        ? arrayMetadata.codecs[0].configuration.chunk_shape
+        : arrayMetadata.chunk_grid.configuration.chunk_shape
+
+      console.log('chunks', chunks)
+      fill_value = arrayMetadata.fill_value
+      // dtype = arrayMetadata.data_type
+
+      loaders = {}
+      await Promise.all(
+        levels.map(
+          (level) =>
+            new Promise((resolve) => {
+              zarr(window.fetch, version).open(
+                `${source}/${level}/${variable}`,
+                (err, get) => {
+                  loaders[`${level}/${variable}`] = get
+                  resolve()
+                }
+              )
+            })
+        )
+      )
+      await Promise.all(
+        coordinateKeys.map(
+          (key) =>
+            new Promise((resolve) => {
+              zarr(window.fetch, version).open(
+                `${source}/${levels[0]}/${key}`,
+                (err, get) => {
+                  get([0], (err, chunk) => {
+                    coordinates[key] = Array.from(chunk.data)
+                    resolve()
+                  })
+                }
+              )
+            })
+        )
+      )
+      break
+    default:
+      throw new Error(
+        `Unexpected Zarr version: ${version}. Must be one of 'v1', 'v2'.`
+      )
+  }
+
+  return {
+    metadata,
+    loaders,
+    dimensions,
+    shape,
+    chunks,
+    fill_value,
+    dtype,
+    coordinates,
+    levels,
+    maxZoom,
+    tileSize,
+  }
+}
+
+export default initializeStore

--- a/src/initialize-store.js
+++ b/src/initialize-store.js
@@ -62,8 +62,6 @@ const initializeStore = async (source, version, variable, coordinateKeys) => {
       chunks = isSharded
         ? arrayMetadata.codecs[0].configuration.chunk_shape
         : arrayMetadata.chunk_grid.configuration.chunk_shape
-
-      console.log('chunks', chunks)
       fill_value = arrayMetadata.fill_value
       // dtype = arrayMetadata.data_type
 

--- a/src/initialize-store.js
+++ b/src/initialize-store.js
@@ -66,8 +66,8 @@ const initializeStore = async (source, version, variable, coordinateKeys) => {
       // dtype = arrayMetadata.data_type
 
       loaders = {}
-      await Promise.all(
-        levels.map(
+      await Promise.all([
+        ...levels.map(
           (level) =>
             new Promise((resolve) => {
               zarr(window.fetch, version).open(
@@ -79,10 +79,8 @@ const initializeStore = async (source, version, variable, coordinateKeys) => {
                 level === 0 ? arrayMetadata : null
               )
             })
-        )
-      )
-      await Promise.all(
-        coordinateKeys.map(
+        ),
+        ...coordinateKeys.map(
           (key) =>
             new Promise((resolve) => {
               zarr(window.fetch, version).open(
@@ -95,8 +93,8 @@ const initializeStore = async (source, version, variable, coordinateKeys) => {
                 }
               )
             })
-        )
-      )
+        ),
+      ])
       break
     default:
       throw new Error(

--- a/src/initialize-store.js
+++ b/src/initialize-store.js
@@ -75,7 +75,8 @@ const initializeStore = async (source, version, variable, coordinateKeys) => {
                 (err, get) => {
                   loaders[`${level}/${variable}`] = get
                   resolve()
-                }
+                },
+                level === 0 ? arrayMetadata : null
               )
             })
         )

--- a/src/shaders.js
+++ b/src/shaders.js
@@ -54,13 +54,8 @@ export const vert = (mode, vars) => {
 
     // [0, 1]
     float posY = clamp(mercatorYFromLat(latRad), 0.0, 1.0);
-    // float posY = clamp(mercator(0.0, latRad).y, 0.0, 1.0);
-
     // [-1, 1]
     posY = posY * 2.0 - 1.0;
-    
-    // [0.5, 0, 0.5]
-    lat = abs(2.0 * latRad / PI);
 
     float scale = pixelRatio * 512.0 / size;
     float globalMag = pow(2.0, zoom - globalLevel);
@@ -71,8 +66,7 @@ export const vert = (mode, vars) => {
     vec2 scaleFactor = vec2(order.x / viewportWidth, -1.0 * order.y / viewportHeight) * scale * 2.0;
 
     float x = scaleFactor.x * (tileOffset.x - cameraOffset.x);
-    float y = mag * posY + scaleFactor.y * cameraOffset.y;
-    // float y = mag * posY;
+    float y = pow(2.0, zoom - 0.6812) * posY + scaleFactor.y * cameraOffset.y - pow(2.0, zoom - 0.6812);
 
     ${sh(`uv = vec2(position.y, position.x) / size;`, ['texture'])}
     ${sh(vars.map((d) => `${d}v = ${d};`).join(''), ['grid', 'dotgrid'])}
@@ -97,7 +91,6 @@ export const frag = (mode, vars, customFrag, customUniforms) => {
   uniform float fillValue;
   uniform float pixelRatio;
   uniform float projection;
-  varying float lat;
   ${sh(`varying vec2 uv;`, ['texture'])}
   ${sh(vars.map((d) => `uniform sampler2D ${d};`).join(''), ['texture'])}
   ${sh(vars.map((d) => `varying float ${d}v;`).join(''), ['grid', 'dotgrid'])}
@@ -143,8 +136,7 @@ export const frag = (mode, vars, customFrag, customUniforms) => {
       }
       float rescaled = (${vars[0]} - clim.x)/(clim.y - clim.x);
       vec4 c = texture2D(colormap, vec2(rescaled, 1.0));
-      // gl_FragColor = vec4(c.x, c.y, c.z, opacity);
-      gl_FragColor = vec4(lat, 0.0, 0.0, 1.0);
+      gl_FragColor = vec4(c.x, c.y, c.z, opacity);
       gl_FragColor.rgb *= gl_FragColor.a;
     }`
 

--- a/src/shaders.js
+++ b/src/shaders.js
@@ -131,10 +131,10 @@ export const frag = (mode, vars, customFrag, customUniforms) => {
       if (projection == 1.0) {
         float scale = pixelRatio * 512.0;
         float mag = pow(2.0, zoom);
-        float y = gl_FragCoord.y * 2.0 - viewportHeight;
-        float mercatorY = (y - centerY) / (mag * scale);
-
-        vec2 lookup = mercatorInvert((uv.y * 2.0 - 1.0) * PI, mercatorY * PI);        
+        float y = gl_FragCoord.y / viewportHeight; // 1 -> 0
+        float delta = 1.0 - centerY; // 0 -> 1 => 1 -> 0
+        float mercatorY = viewportHeight * (y - 0.5) / (scale * mag) + delta;
+        vec2 lookup = mercatorInvert((uv.y * 2.0 - 1.0) * PI, (mercatorY * 2.0 - 1.0) * PI);
         float rescaledX = lookup.x / 360.0 + 0.5;
         float numTiles = pow(2.0, level);
         float sizeRad = PI / numTiles;

--- a/src/shaders.js
+++ b/src/shaders.js
@@ -133,10 +133,6 @@ export const frag = (mode, vars, customFrag, customUniforms) => {
         float rescaledX = lookup.x / 360.0 + 0.5;
         float rescaledY = order.y * (latBase - radians(lookup.y)) / sizeRad;
 
-        if (rescaledY > 1.0 || rescaledY < 0.0) {
-          discard;
-        }
-
         coord = vec2(rescaledY, rescaledX);
       }
 

--- a/src/shaders.js
+++ b/src/shaders.js
@@ -54,7 +54,7 @@ export const vert = (mode, vars) => {
     // [-1, 1]
     posY = posY * 2.0 - 1.0;
 
-    return pow(2.0, zoom - 0.6812) * posY + scaleFactor.y * cameraOffset.y - pow(2.0, zoom - 0.6812);
+    return pow(2.0, zoom) * posY + scaleFactor.y * cameraOffset.y - pow(2.0, zoom);
   }
 
   void main() {
@@ -138,8 +138,8 @@ export const frag = (mode, vars, customFrag, customUniforms) => {
       if (projection == 1.0) {
         float scale = pixelRatio * 512.0;
         float mag = pow(2.0, zoom);
-        float y = 2.0 * (gl_FragCoord.y - 0.5 * viewportHeight) / viewportHeight;
-        float mercatorY = y * viewportHeight / (mag * scale) - centerY + 0.5;
+        float y = gl_FragCoord.y * 2.0 - viewportHeight;
+        float mercatorY = (y - centerY) / (mag * scale);
 
         vec2 lookup = mercatorInvert((uv.y * 2.0 - 1.0) * PI, mercatorY * PI);        
         float rescaledX = lookup.x / 360.0 + 0.5;

--- a/src/shaders.js
+++ b/src/shaders.js
@@ -70,7 +70,7 @@ export const vert = (mode, vars) => {
       // [-1, 1]
       posY = posY * 2.0 - 1.0;
   
-      y = pow(2.0, zoom + 1.0 - level) * posY - scaleFactor.y * cameraOffset.y;
+      y = pow(2.0, zoom + 1.0 - level) * posY + scaleFactor.y * (cameraOffset.y - globalMag * size * pow(2.0, globalLevel) * 0.5);
 
       // values when position.y = 0
       latBase = order.y * (PI / 2.0 - (offset.y * sizeRad));

--- a/src/shaders.js
+++ b/src/shaders.js
@@ -67,10 +67,10 @@ export const vert = (mode, vars) => {
 
       // [0, 1]
       float posY = clamp(mercatorYFromLat(latRad), 0.0, 1.0);
-      // [-1, 1]
-      posY = posY * 2.0 - 1.0;
+      // [-0.5, 0.5]
+      posY = posY - 0.5;
   
-      y = pow(2.0, zoom + 1.0 - level) * posY + scaleFactor.y * (cameraOffset.y - globalMag * size * pow(2.0, globalLevel) * 0.5);
+      y = scaleFactor.y * (pow(2.0, zoom) * size * posY + cameraOffset.y - globalMag * size * pow(2.0, globalLevel) * 0.5);
 
       // values when position.y = 0
       latBase = order.y * (PI / 2.0 - (offset.y * sizeRad));

--- a/src/shaders.js
+++ b/src/shaders.js
@@ -27,6 +27,7 @@ export const vert = (mode, vars) => {
   uniform float globalLevel;
   uniform float level;
   uniform vec2 offset;
+  uniform vec2 order;
   void main() {
     float scale = pixelRatio * 512.0 / size;
     float globalMag = pow(2.0, zoom - globalLevel);
@@ -35,8 +36,9 @@ export const vert = (mode, vars) => {
     float y = mag * (position.y + offset.y * size) - globalMag * camera.y * size ;
     x = (scale * x);
     y = (scale * y);
-    x = (2.0 * x / viewportWidth);
-    y = -(2.0 * y / viewportHeight);
+    x = order.x * (2.0 * x / viewportWidth);
+    y = order.y * -(2.0 * y / viewportHeight);
+
     ${sh(`uv = vec2(position.y, position.x) / size;`, ['texture'])}
     ${sh(vars.map((d) => `${d}v = ${d};`).join(''), ['grid', 'dotgrid'])}
     ${sh(`gl_PointSize = 0.9 * scale * mag;`, ['grid', 'dotgrid'])}

--- a/src/shaders.js
+++ b/src/shaders.js
@@ -64,14 +64,14 @@ export const vert = (mode, vars) => {
       float sizeRad = PI / numTiles;
       float stepRad = sizeRad / size;  
       float latRad = order.y * (PI / 2.0 - (offset.y * sizeRad + position.y * stepRad));
-  
+
       // [0, 1]
       float posY = clamp(mercatorYFromLat(latRad), 0.0, 1.0);
       // [-1, 1]
       posY = posY * 2.0 - 1.0;
   
-      y = pow(2.0, zoom) * posY + scaleFactor.y * cameraOffset.y - pow(2.0, zoom);
-      
+      y = pow(2.0, zoom + 1.0 - level) * posY - scaleFactor.y * cameraOffset.y;
+
       // values when position.y = 0
       latBase = order.y * (PI / 2.0 - (offset.y * sizeRad));
     } else {

--- a/src/shaders.js
+++ b/src/shaders.js
@@ -33,7 +33,6 @@ export const vert = (mode, vars) => {
   uniform vec2 offset;
   uniform vec2 order;
   uniform float projection;
-  varying float lat;
   varying float latBase;
   vec2 mercator(float lambda, float phi)
   {

--- a/src/tile.js
+++ b/src/tile.js
@@ -192,9 +192,9 @@ class Tile {
           const dimension = this.dimensions[i]
           const chunkOffset = chunk[i] * count
 
-          if (dimension === 'x') {
+          if (['x', 'lon'].includes(dimension)) {
             return accum.map((prev) => [...prev, x])
-          } else if (dimension === 'y') {
+          } else if (['y', 'lat'].includes(dimension)) {
             return accum.map((prev) => [...prev, y])
           } else if (selector.hasOwnProperty(dimension)) {
             const selectorValues = Array.isArray(selector[dimension])
@@ -240,7 +240,7 @@ class Tile {
           return accum
         }, [])
         const chunkIndices = indices.map((el, i) =>
-          ['x', 'y'].includes(this.dimensions[i])
+          ['x', 'lon', 'y', 'lat'].includes(this.dimensions[i])
             ? el
             : el - chunk[i] * this.chunks[i]
         )

--- a/src/tile.js
+++ b/src/tile.js
@@ -13,7 +13,6 @@ class Tile {
     chunks,
     dimensions,
     coordinates,
-    order,
     bands,
     initializeBuffer,
   }) {
@@ -25,7 +24,6 @@ class Tile {
     this.dimensions = dimensions
     this.coordinates = coordinates
     this.bands = bands
-    this.order = order
 
     this._bufferCache = null
     this._buffers = {}
@@ -104,19 +102,7 @@ class Tile {
       }
       const chunk = chunks[0]
       const chunkKey = chunk.join('.')
-      const data = this.chunkedData[chunkKey].step(
-        ...(this.order
-          ? this.dimensions.map((dimension) => {
-              if (['x', 'lon'].includes(dimension)) {
-                return this.order[0]
-              } else if (['y', 'lat'].includes(dimension)) {
-                return this.order[1]
-              } else {
-                return 1
-              }
-            })
-          : this.dimensions.map((d) => 1))
-      )
+      const data = this.chunkedData[chunkKey]
 
       if (!data) {
         throw new Error(`Missing data for chunk: ${chunkKey}`)

--- a/src/tile.js
+++ b/src/tile.js
@@ -13,6 +13,7 @@ class Tile {
     chunks,
     dimensions,
     coordinates,
+    order,
     bands,
     initializeBuffer,
   }) {
@@ -24,6 +25,7 @@ class Tile {
     this.dimensions = dimensions
     this.coordinates = coordinates
     this.bands = bands
+    this.order = order
 
     this._bufferCache = null
     this._buffers = {}
@@ -102,7 +104,19 @@ class Tile {
       }
       const chunk = chunks[0]
       const chunkKey = chunk.join('.')
-      const data = this.chunkedData[chunkKey].step(1, -1, 1)
+      const data = this.chunkedData[chunkKey].step(
+        ...(this.order
+          ? this.dimensions.map((dimension) => {
+              if (['x', 'lon'].includes(dimension)) {
+                return this.order[0]
+              } else if (['y', 'lat'].includes(dimension)) {
+                return this.order[1]
+              } else {
+                return 1
+              }
+            })
+          : this.dimensions.map((d) => 1))
+      )
 
       if (!data) {
         throw new Error(`Missing data for chunk: ${chunkKey}`)

--- a/src/tile.js
+++ b/src/tile.js
@@ -102,7 +102,7 @@ class Tile {
       }
       const chunk = chunks[0]
       const chunkKey = chunk.join('.')
-      const data = this.chunkedData[chunkKey]
+      const data = this.chunkedData[chunkKey].step(1, -1, 1)
 
       if (!data) {
         throw new Error(`Missing data for chunk: ${chunkKey}`)

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -233,6 +233,8 @@ export const createTiles = (regl, opts) => {
       const adjustedActive = Object.keys(this.tiles)
         .filter((key) => this.active[key])
         .reduce((accum, key) => {
+          // Get optimum set of keys to render based on which have been fully loaded
+          // (potentially mixing levels of pyramid)
           const keysToRender = getKeysToRender(key, this.tiles, this.maxZoom)
           keysToRender.forEach((keyToRender) => {
             const offsets = this.active[key]

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -57,6 +57,7 @@ export const createTiles = (regl, opts) => {
     this.variable = variable
     this.fillValue = fillValue
     this.projection = projection
+    this.projectionIndex = ['mercator', 'equirectangular'].indexOf(projection)
     this.order = order ?? [1, 1]
     this.invalidate = invalidate
     this.viewport = { viewportHeight: 0, viewportWidth: 0 }
@@ -201,6 +202,7 @@ export const createTiles = (regl, opts) => {
         camera: regl.this('camera'),
         size: regl.this('size'),
         zoom: regl.this('zoom'),
+        projection: regl.this('projectionIndex'),
         globalLevel: regl.this('level'),
         level: regl.prop('level'),
         offset: regl.prop('offset'),

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -318,8 +318,6 @@ export const createTiles = (regl, opts) => {
       this.zoom = zoom
       this.camera = [camera[0], camera[1]]
       this.centerY = mercatorYFromLat(center.lat)
-      console.log(this.centerY, center.lat)
-      console.log(this.camera)
 
       this.active = getSiblings(tile, {
         viewport: this.viewport,

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -201,7 +201,7 @@ export const createTiles = (regl, opts) => {
         globalLevel: regl.this('level'),
         level: regl.prop('level'),
         offset: regl.prop('offset'),
-        order: regl.prop('order'),
+        order: regl.this('order'),
         clim: regl.this('clim'),
         opacity: regl.this('opacity'),
         fillValue: regl.this('fillValue'),
@@ -265,7 +265,6 @@ export const createTiles = (regl, opts) => {
           offsets.forEach((offset) => {
             accum.push({
               ...tile.getBuffers(),
-              order: this.order,
               level,
               offset,
             })
@@ -292,7 +291,13 @@ export const createTiles = (regl, opts) => {
 
     this.updateCamera = ({ center, zoom }) => {
       const level = zoomToLevel(zoom, this.maxZoom)
-      const tile = pointToTile(center.lng, center.lat, level, this.projection)
+      const tile = pointToTile(
+        center.lng,
+        center.lat,
+        level,
+        this.projection,
+        this.order
+      )
       const camera = pointToCamera(center.lng, center.lat, level)
 
       this.level = level
@@ -379,7 +384,12 @@ export const createTiles = (regl, opts) => {
     this.queryRegion = async (region, selector) => {
       await this.initialized
 
-      const tiles = getTilesOfRegion(region, this.level, this.projection)
+      const tiles = getTilesOfRegion(
+        region,
+        this.level,
+        this.projection,
+        this.order
+      )
 
       await Promise.all(
         tiles.map(async (key) => {

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -24,6 +24,15 @@ import {
 import { DEFAULT_FILL_VALUES } from './constants'
 import Tile from './tile'
 
+function mercatorYFromLat(lat) {
+  return (
+    (180 -
+      (180 / Math.PI) *
+        Math.log(Math.tan(Math.PI / 4 + (lat * Math.PI) / 360))) /
+    360
+  )
+}
+
 export const createTiles = (regl, opts) => {
   return new Tiles(opts)
 
@@ -199,6 +208,7 @@ export const createTiles = (regl, opts) => {
         pixelRatio: regl.context('pixelRatio'),
         colormap: regl.this('colormap'),
         camera: regl.this('camera'),
+        centerY: regl.this('centerY'),
         size: regl.this('size'),
         zoom: regl.this('zoom'),
         projection: regl.this('projectionIndex'),
@@ -307,6 +317,8 @@ export const createTiles = (regl, opts) => {
       this.level = level
       this.zoom = zoom
       this.camera = [camera[0], camera[1]]
+      this.centerY = mercatorYFromLat(center.lat)
+      console.log(this.centerY, center.lat)
       console.log(this.camera)
 
       this.active = getSiblings(tile, {

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -309,15 +309,13 @@ export const createTiles = (regl, opts) => {
       this.camera = [camera[0], camera[1]]
       console.log(this.camera)
 
-      // this.active = getSiblings(tile, {
-      //   viewport: this.viewport,
-      //   zoom,
-      //   camera: this.camera,
-      //   size: this.size,
-      //   projection: this.projection,
-      // })
-
-      this.active = { '0,1,1': [[0, 1, 1]] }
+      this.active = getSiblings(tile, {
+        viewport: this.viewport,
+        zoom,
+        camera: this.camera,
+        size: this.size,
+        projection: this.projection,
+      })
 
       if (this.size && Object.keys(this.active).length === 0) {
         this.clearLoading(null, { forceClear: true })

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -165,7 +165,6 @@ export const createTiles = (regl, opts) => {
                     this.tiles[key] = new Tile({
                       key,
                       loader,
-                      order: this.order,
                       shape: this.shape,
                       chunks: this.chunks,
                       dimensions: this.dimensions,
@@ -206,6 +205,7 @@ export const createTiles = (regl, opts) => {
         globalLevel: regl.this('level'),
         level: regl.prop('level'),
         offset: regl.prop('offset'),
+        order: regl.prop('order'),
         clim: regl.this('clim'),
         opacity: regl.this('opacity'),
         fillValue: regl.this('fillValue'),
@@ -240,11 +240,7 @@ export const createTiles = (regl, opts) => {
             const offsets = this.active[key]
 
             offsets.forEach((offset) => {
-              const adjustedOffset = getAdjustedOffset(
-                offset,
-                keyToRender,
-                this.order
-              )
+              const adjustedOffset = getAdjustedOffset(offset, keyToRender)
               if (!accum[keyToRender]) {
                 accum[keyToRender] = []
               }
@@ -273,6 +269,7 @@ export const createTiles = (regl, opts) => {
           offsets.forEach((offset) => {
             accum.push({
               ...tile.getBuffers(),
+              order: this.order,
               level,
               offset,
             })
@@ -299,18 +296,11 @@ export const createTiles = (regl, opts) => {
 
     this.updateCamera = ({ center, zoom }) => {
       const level = zoomToLevel(zoom, this.maxZoom)
-      const tile = pointToTile(
-        center.lng,
-        center.lat,
-        level,
-        this.order,
-        this.projection
-      )
+      const tile = pointToTile(center.lng, center.lat, level, this.projection)
       const camera = pointToCamera(
         center.lng,
         center.lat,
         level,
-        this.order,
         this.projection
       )
 
@@ -323,7 +313,7 @@ export const createTiles = (regl, opts) => {
         zoom,
         camera: this.camera,
         size: this.size,
-        order: this.order,
+        projection: this.projection,
       })
 
       if (this.size && Object.keys(this.active).length === 0) {
@@ -396,12 +386,7 @@ export const createTiles = (regl, opts) => {
     this.queryRegion = async (region, selector) => {
       await this.initialized
 
-      const tiles = getTilesOfRegion(
-        region,
-        this.level,
-        this.order,
-        this.projection
-      )
+      const tiles = getTilesOfRegion(region, this.level, this.projection)
 
       await Promise.all(
         tiles.map(async (key) => {

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -307,14 +307,17 @@ export const createTiles = (regl, opts) => {
       this.level = level
       this.zoom = zoom
       this.camera = [camera[0], camera[1]]
+      console.log(this.camera)
 
-      this.active = getSiblings(tile, {
-        viewport: this.viewport,
-        zoom,
-        camera: this.camera,
-        size: this.size,
-        projection: this.projection,
-      })
+      // this.active = getSiblings(tile, {
+      //   viewport: this.viewport,
+      //   zoom,
+      //   camera: this.camera,
+      //   size: this.size,
+      //   projection: this.projection,
+      // })
+
+      this.active = { '0,1,1': [[0, 1, 1]] }
 
       if (this.size && Object.keys(this.active).length === 0) {
         this.clearLoading(null, { forceClear: true })

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -240,7 +240,11 @@ export const createTiles = (regl, opts) => {
             const offsets = this.active[key]
 
             offsets.forEach((offset) => {
-              const adjustedOffset = getAdjustedOffset(offset, keyToRender)
+              const adjustedOffset = getAdjustedOffset(
+                offset,
+                keyToRender,
+                this.order
+              )
               if (!accum[keyToRender]) {
                 accum[keyToRender] = []
               }
@@ -319,6 +323,7 @@ export const createTiles = (regl, opts) => {
         zoom,
         camera: this.camera,
         size: this.size,
+        order: this.order,
       })
 
       if (this.size && Object.keys(this.active).length === 0) {

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -133,7 +133,6 @@ export const createTiles = (regl, opts) => {
           this.dimensions = dimensions
           this.shape = shape
           this.chunks = chunks
-          console.log('chunks here', chunks)
           this.fillValue = fillValue ?? fill_value ?? DEFAULT_FILL_VALUES[dtype]
 
           if (mode === 'texture') {

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -20,18 +20,10 @@ import {
   setObjectValues,
   getChunks,
   getSelectorHash,
+  mercatorYFromLat,
 } from './utils'
 import { DEFAULT_FILL_VALUES } from './constants'
 import Tile from './tile'
-
-function mercatorYFromLat(lat) {
-  return (
-    (180 -
-      (180 / Math.PI) *
-        Math.log(Math.tan(Math.PI / 4 + (lat * Math.PI) / 360))) /
-    360
-  )
-}
 
 export const createTiles = (regl, opts) => {
   return new Tiles(opts)
@@ -307,12 +299,7 @@ export const createTiles = (regl, opts) => {
     this.updateCamera = ({ center, zoom }) => {
       const level = zoomToLevel(zoom, this.maxZoom)
       const tile = pointToTile(center.lng, center.lat, level, this.projection)
-      const camera = pointToCamera(
-        center.lng,
-        center.lat,
-        level,
-        this.projection
-      )
+      const camera = pointToCamera(center.lng, center.lat, level)
 
       this.level = level
       this.zoom = zoom

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -311,6 +311,7 @@ export const createTiles = (regl, opts) => {
         zoom,
         camera: this.camera,
         size: this.size,
+        order: this.order,
         projection: this.projection,
       })
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -38,23 +38,20 @@ export const pointToCamera = (lon, lat, z, projection) => {
   const sin = Math.sin(lat * d2r)
   const z2 = Math.pow(2, z)
 
-  x = z2 * (lon / 360 + 0.5)
-  y = z2 * (0.5 - (0.25 * Math.log((1 + sin) / (1 - sin))) / Math.PI)
-
   switch (projection) {
     case 'mercator':
       x = z2 * (lon / 360 + 0.5)
       y = z2 * (0.5 - (0.25 * Math.log((1 + sin) / (1 - sin))) / Math.PI)
+      y = Math.max(Math.min(y, z2), 0)
       break
     case 'equirectangular':
-    // x = z2 * (lon / 360 + 0.5)
-    // y = z2 * (lat / 180 + 0.5)
+      x = z2 * (lon / 360 + 0.5)
+      y = z2 * ((0.25 * Math.log((1 + sin) / (1 - sin))) / Math.PI)
     default:
       break
   }
 
   x = x % z2
-  y = Math.max(Math.min(y, z2), 0)
   if (x < 0) x = x + z2
   return [x, y, z]
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -131,6 +131,11 @@ export const getSiblings = (
   const max = Math.pow(2, tileZ) - 1
   return offsets.reduce((accum, offset) => {
     const [x, y, z] = offset
+
+    // Do not attempt to wrap in y direction
+    if (y < 0 || y > max) {
+      return accum
+    }
     const tile = [clip(x, max), clip(y, max), z]
     const key = tileToKey(tile)
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -96,7 +96,7 @@ const getOffsets = (length, tileSize, camera) => {
 
 // Given a tile, return an object mapping sibling tiles (including itself) mapped to the different locations to render
 // For example, { '0.0.0':  [ [0,0,0], [1,0,0] ] }
-export const getSiblings = (tile, { viewport, zoom, size, camera }) => {
+export const getSiblings = (tile, { viewport, zoom, size, camera, order }) => {
   const [tileX, tileY, tileZ] = tile
   const { viewportHeight, viewportWidth } = viewport
   const [cameraX, cameraY] = camera
@@ -111,7 +111,7 @@ export const getSiblings = (tile, { viewport, zoom, size, camera }) => {
   let offsets = []
   for (let x = deltaX[0]; x <= deltaX[1]; x++) {
     for (let y = deltaY[0]; y <= deltaY[1]; y++) {
-      offsets.push([tileX + x, tileY + y, tileZ])
+      offsets.push([tileX + order[0] * x, tileY + order[1] * y, tileZ])
     }
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -94,6 +94,8 @@ const getOffsets = (length, tileSize, camera) => {
   return [-1 * Math.ceil(prev), Math.ceil(next)]
 }
 
+// Given a tile, return an object mapping sibling tiles (including itself) mapped to the different locations to render
+// For example, { '0.0.0':  [ [0,0,0], [1,0,0] ] }
 export const getSiblings = (tile, { viewport, zoom, size, camera }) => {
   const [tileX, tileY, tileZ] = tile
   const { viewportHeight, viewportWidth } = viewport
@@ -209,6 +211,8 @@ export const getOverlappingAncestor = (key, renderedKeys) => {
   })
 }
 
+// Given a `renderedKey` for a tile to be rendered at some offset on the map,
+// return offset for rendering in context of map
 export const getAdjustedOffset = (offset, renderedKey) => {
   const [renderedX, renderedY, renderedLevel] = keyToTile(renderedKey)
   const [offsetX, offsetY, level] = offset

--- a/src/utils.js
+++ b/src/utils.js
@@ -26,7 +26,23 @@ export const tileToKey = (tile) => {
 
 export const pointToTile = (lon, lat, z, projection) => {
   const z2 = Math.pow(2, z)
-  let tile = pointToCamera(lon, lat, z, projection)
+
+  let tile
+  switch (projection) {
+    case 'mercator':
+      tile = pointToCamera(lon, lat, z, projection)
+      break
+    case 'equirectangular':
+      let x = z2 * (lon / 360 + 0.5)
+      let y = z2 * (lat / 180 + 0.5)
+
+      x = x % z2
+      if (x < 0) x = x + z2
+      y = Math.max(Math.min(y, z2), 0)
+      tile = [x, y, z]
+    default:
+      break
+  }
   tile[0] = Math.floor(tile[0])
   tile[1] = Math.min(Math.floor(tile[1]), z2 - 1)
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -324,12 +324,10 @@ export const getTilesOfRegion = (region, level, projection) => {
   return Array.from(tiles)
 }
 
-export const getPyramidMetadata = (metadata) => {
-  const multiscales = metadata.metadata['.zattrs'].multiscales
-
+export const getPyramidMetadata = (multiscales) => {
   if (!multiscales) {
     throw new Error(
-      'Missing `multiscales` value in .zattrs. Please check your pyramid generation code.'
+      'Missing `multiscales` value in metadata. Please check your pyramid generation code.'
     )
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,7 +24,7 @@ export const tileToKey = (tile) => {
   return tile.join(',')
 }
 
-export const pointToTile = (lon, lat, z, projection) => {
+export const pointToTile = (lon, lat, z, projection, order) => {
   const z2 = Math.pow(2, z)
 
   let tile
@@ -34,7 +34,7 @@ export const pointToTile = (lon, lat, z, projection) => {
       break
     case 'equirectangular':
       let x = z2 * (lon / 360 + 0.5)
-      let y = z2 * (lat / 180 + 0.5)
+      let y = z2 * ((order[1] * -1 * lat) / 180 + 0.5)
 
       x = x % z2
       if (x < 0) x = x + z2
@@ -283,15 +283,21 @@ export const getAdjustedOffset = (offset, renderedKey) => {
   ]
 }
 
-export const getTilesOfRegion = (region, level, projection) => {
+export const getTilesOfRegion = (region, level, projection, order) => {
   const { center, radius, units } = region.properties
-  const centralTile = pointToTile(center.lng, center.lat, level, projection)
+  const centralTile = pointToTile(
+    center.lng,
+    center.lat,
+    level,
+    projection,
+    order
+  )
 
   const tiles = new Set([tileToKey(centralTile)])
 
   region.geometry.coordinates[0].forEach(([lng, lat]) => {
     // Add tile along edge of region
-    const edgeTile = pointToTile(lng, lat, level, projection)
+    const edgeTile = pointToTile(lng, lat, level, projection, order)
     tiles.add(tileToKey(edgeTile))
 
     // Add any intermediate tiles if edge is > 1 tile away from center
@@ -314,7 +320,8 @@ export const getTilesOfRegion = (region, level, projection) => {
           intermediatePoint.geometry.coordinates[0],
           intermediatePoint.geometry.coordinates[1],
           level,
-          projection
+          projection,
+          order
         )
         tiles.add(tileToKey(intermediateTile))
       }

--- a/src/utils.js
+++ b/src/utils.js
@@ -126,7 +126,7 @@ const getLatBasedOffsets = (tile, { zoom, length, order, camera }) => {
   const scale = window.devicePixelRatio * 512 * magnification
   const tileSize = Math.abs(y1 - y0) * scale
 
-  const cameraOffset = camera - Math.pow(2, z) * y1
+  const cameraOffset = camera - Math.pow(2, z) * (order === 1 ? y0 : y1)
 
   return getOffsets(length, tileSize, cameraOffset, order)
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -38,14 +38,17 @@ export const pointToCamera = (lon, lat, z, projection) => {
   const sin = Math.sin(lat * d2r)
   const z2 = Math.pow(2, z)
 
+  x = z2 * (lon / 360 + 0.5)
+  y = z2 * (0.5 - (0.25 * Math.log((1 + sin) / (1 - sin))) / Math.PI)
+
   switch (projection) {
     case 'mercator':
       x = z2 * (lon / 360 + 0.5)
       y = z2 * (0.5 - (0.25 * Math.log((1 + sin) / (1 - sin))) / Math.PI)
       break
     case 'equirectangular':
-      x = z2 * (lon / 360 + 0.5)
-      y = z2 * (lat / 180 + 0.5)
+    // x = z2 * (lon / 360 + 0.5)
+    // y = z2 * (lat / 180 + 0.5)
     default:
       break
   }


### PR DESCRIPTION
This PR updates the `Raster` component to accept three new optional props, `projection`, `version`, and `order`. Each defaults to the previous expectation of `mercator`, `v2`, and `[1, 1]` respectively.
- The Zarr `version` dictates how metadata is fetched and how loaders are initialized, with this logic being consolidated in an `initializeStore()` helper. When `version='v3'`, it also possible to chunks from sharded datasets.
- The `projection` describes how the raster data is _stored_ rather than how it's _rendered_. This dictates which chunks to fetch and how they are each positioned and rendered. Note that using the `equirectangular` projection means that chunks will no longer neatly align with the standard slippy map tiles used by Mapbox (though they will still align in the x direction).
- The `order` prop is an array dictates whether the raster data should be reordered in the x and y directions, where the default `[1, 1]` assumes left -> right and top -> bottom rendering, respectively. Flipping either value to `-1` will swap the rendering in that dimension. 