### PR TITLE
Fix invalid tile key issues when swapping rasters when region picker active

### DIFF
--- a/src/tiles.js
+++ b/src/tiles.js
@@ -403,10 +403,9 @@ export const createTiles = (regl, opts) => {
             tileIndex[0],
             tileIndex[1]
           )
-
-          if (!this.tiles[key].hasLoadedChunks(chunks)) {
+          if (!this.tiles[key]?.hasLoadedChunks(chunks)) {
             const loadingID = this.setLoading('chunk')
-            await this.tiles[key].loadChunks(chunks)
+            await this.tiles[key]?.loadChunks(chunks)
             this.clearLoading(loadingID)
           }
         })

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -403,7 +403,7 @@ export const createTiles = (regl, opts) => {
             tileIndex[0],
             tileIndex[1]
           )
-          if (this.tiles[key] && !this.tiles[key].hasLoadedChunks(chunks)) {
+          if (!this.tiles[key].hasLoadedChunks(chunks)) {
             const loadingID = this.setLoading('chunk')
             await this.tiles[key].loadChunks(chunks)
             this.clearLoading(loadingID)

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -403,9 +403,9 @@ export const createTiles = (regl, opts) => {
             tileIndex[0],
             tileIndex[1]
           )
-          if (!this.tiles[key]?.hasLoadedChunks(chunks)) {
+          if (this.tiles[key] && !this.tiles[key].hasLoadedChunks(chunks)) {
             const loadingID = this.setLoading('chunk')
-            await this.tiles[key]?.loadChunks(chunks)
+            await this.tiles[key].loadChunks(chunks)
             this.clearLoading(loadingID)
           }
         })

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -120,6 +120,7 @@ export const createTiles = (regl, opts) => {
         }) => {
           if (setMetadata) setMetadata(metadata)
           this.maxZoom = maxZoom
+          this.level = zoomToLevel(this.zoom, maxZoom)
           const position = getPositions(tileSize, mode)
           this.position = regl.buffer(position)
           this.size = tileSize
@@ -383,9 +384,6 @@ export const createTiles = (regl, opts) => {
 
     this.queryRegion = async (region, selector) => {
       await this.initialized
-
-      // update level since it can get out of sync when switching raster layers
-      this.level = zoomToLevel(this.zoom, this.maxZoom)
 
       const tiles = getTilesOfRegion(
         region,

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -403,6 +403,7 @@ export const createTiles = (regl, opts) => {
             tileIndex[0],
             tileIndex[1]
           )
+
           if (!this.tiles[key].hasLoadedChunks(chunks)) {
             const loadingID = this.setLoading('chunk')
             await this.tiles[key].loadChunks(chunks)

--- a/src/tiles.js
+++ b/src/tiles.js
@@ -384,6 +384,9 @@ export const createTiles = (regl, opts) => {
     this.queryRegion = async (region, selector) => {
       await this.initialized
 
+      // update level since it can get out of sync when switching raster layers
+      this.level = zoomToLevel(this.zoom, this.maxZoom)
+
       const tiles = getTilesOfRegion(
         region,
         this.level,

--- a/src/use-controls.js
+++ b/src/use-controls.js
@@ -19,7 +19,7 @@ export const useControls = () => {
     return () => {
       map.off('move', updateControlsSync)
     }
-  }, [map])
+  }, [])
 
   return { center: center, zoom: zoom }
 }

--- a/src/use-controls.js
+++ b/src/use-controls.js
@@ -3,9 +3,9 @@ import { flushSync } from 'react-dom'
 import { useMapbox } from './mapbox'
 
 export const useControls = () => {
-  const [zoom, setZoom] = useState()
-  const [center, setCenter] = useState()
   const { map } = useMapbox()
+  const [zoom, setZoom] = useState(map.getZoom())
+  const [center, setCenter] = useState(map.getCenter())
 
   const updateControlsSync = useCallback(() => {
     flushSync(() => {
@@ -15,10 +15,10 @@ export const useControls = () => {
   }, [])
 
   useEffect(() => {
-    setZoom(map.getZoom())
-    setCenter(map.getCenter())
-    map.on('load', updateControlsSync)
     map.on('move', updateControlsSync)
+    return () => {
+      map.off('move', updateControlsSync)
+    }
   }, [map])
 
   return { center: center, zoom: zoom }

--- a/src/use-controls.js
+++ b/src/use-controls.js
@@ -19,7 +19,7 @@ export const useControls = () => {
     return () => {
       map.off('move', updateControlsSync)
     }
-  }, [])
+  }, [map])
 
   return { center: center, zoom: zoom }
 }


### PR DESCRIPTION
~~Adds a couple checks to make sure we're not accessing the tile before it has been initialized. This solves errors when swapping raster properties (like `variable`) while a region picker is active.~~

Fixes zoom/center state initialization and makes sure dataset level is correctly calculated before querying.