### PR TITLE
rework band info creation to make sure output contains all selector values

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -365,28 +365,36 @@ export const getPyramidMetadata = (multiscales) => {
  * @returns Object containing bandName, {[dimension]: dimensionValue} pairs
  */
 export const getBandInformation = (selector) => {
-  const keys = Object.keys(selector).filter((key) =>
-    Array.isArray(selector[key])
-  )
-  if (keys.length === 0) return {}
-  let combinedBands = {}
-  keys.forEach((key) => {
-    const newCombinedBands = {}
-    selector[key].forEach((value) => {
-      const valueKey = typeof value === 'string' ? value : key + '_' + value
-      if (Object.keys(combinedBands).length === 0) {
-        newCombinedBands[valueKey] = { [key]: value }
+  const combinedBands = Object.keys(selector)
+    .filter((key) => Array.isArray(selector[key]))
+    .reduce((bandMapping, selectorKey) => {
+      const values = selector[selectorKey]
+      let keys
+      if (typeof values[0] === 'string') {
+        keys = values
       } else {
-        Object.keys(combinedBands).forEach((existingKey) => {
-          newCombinedBands[existingKey + '_' + valueKey] = {
-            ...combinedBands[existingKey],
-            [key]: value,
-          }
-        })
+        keys = values.map((d) => selectorKey + '_' + d)
       }
-    })
-    combinedBands = newCombinedBands
-  })
+
+      const bands = Object.keys(bandMapping)
+      const updatedBands = {}
+      keys.forEach((key, i) => {
+        if (bands.length > 0) {
+          bands.forEach((band) => {
+            const bandKey = `${band}_${key}`
+            updatedBands[bandKey] = {
+              ...bandMapping[band],
+              [selectorKey]: values[i],
+            }
+          })
+        } else {
+          updatedBands[key] = { [selectorKey]: values[i] }
+        }
+      })
+
+      return updatedBands
+    }, {})
+
   Object.keys(selector).forEach((key) => {
     if (!Array.isArray(selector[key])) {
       Object.keys(combinedBands).forEach((combinedKey) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -365,36 +365,35 @@ export const getPyramidMetadata = (multiscales) => {
  * @returns Object containing bandName, {[dimension]: dimensionValue} pairs
  */
 export const getBandInformation = (selector) => {
-  const combinedBands = Object.keys(selector)
-    .filter((key) => Array.isArray(selector[key]))
-    .reduce((bandMapping, selectorKey) => {
-      const values = selector[selectorKey]
-      let keys
-      if (typeof values[0] === 'string') {
-        keys = values
+  const keys = Object.keys(selector).filter((key) =>
+    Array.isArray(selector[key])
+  )
+  if (keys.length === 0) return {}
+  let combinedBands = {}
+  keys.forEach((key) => {
+    const newCombinedBands = {}
+    selector[key].forEach((value) => {
+      const valueKey = typeof value === 'string' ? value : key + '_' + value
+      if (Object.keys(combinedBands).length === 0) {
+        newCombinedBands[valueKey] = { [key]: value }
       } else {
-        keys = values.map((d) => selectorKey + '_' + d)
+        Object.keys(combinedBands).forEach((existingKey) => {
+          newCombinedBands[existingKey + '_' + valueKey] = {
+            ...combinedBands[existingKey],
+            [key]: value,
+          }
+        })
       }
-
-      const bands = Object.keys(bandMapping)
-      const updatedBands = {}
-      keys.forEach((key, i) => {
-        if (bands.length > 0) {
-          bands.forEach((band) => {
-            const bandKey = `${band}_${key}`
-            updatedBands[bandKey] = {
-              ...bandMapping[band],
-              [selectorKey]: values[i],
-            }
-          })
-        } else {
-          updatedBands[key] = { [selectorKey]: values[i] }
-        }
+    })
+    combinedBands = newCombinedBands
+  })
+  Object.keys(selector).forEach((key) => {
+    if (!Array.isArray(selector[key])) {
+      Object.keys(combinedBands).forEach((combinedKey) => {
+        combinedBands[combinedKey][key] = selector[key]
       })
-
-      return updatedBands
-    }, {})
-
+    }
+  })
   return combinedBands
 }
 

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,0 +1,71 @@
+import { getBandInformation } from './utils'
+
+describe('utils', () => {
+  describe('getBandInformation()', () => {
+    it('returns no bands for empty selectors', () => {
+      expect(getBandInformation({})).toEqual({})
+    })
+
+    it('returns no bands for non-array selector values', () => {
+      expect(getBandInformation({ time: 0 })).toEqual({})
+      expect(getBandInformation({ time: 0, variable: 'pr' })).toEqual({})
+    })
+
+    it('handles array selector values', () => {
+      expect(getBandInformation({ time: ['jan', 'feb'] })).toEqual({
+        jan: { time: 'jan' },
+        feb: { time: 'feb' },
+      })
+    })
+
+    it('handles array selector values with number entries', () => {
+      expect(getBandInformation({ time: [1, 2] })).toEqual({
+        time_1: { time: 1 },
+        time_2: { time: 2 },
+      })
+    })
+
+    it('handles multiple array selector values', () => {
+      expect(
+        getBandInformation({ time: ['jan', 'feb'], variable: ['pr', 'tavg'] })
+      ).toEqual({
+        jan_pr: { time: 'jan', variable: 'pr' },
+        feb_pr: { time: 'feb', variable: 'pr' },
+        jan_tavg: { time: 'jan', variable: 'tavg' },
+        feb_tavg: { time: 'feb', variable: 'tavg' },
+      })
+    })
+
+    it('handles multiple array selector values with number entries', () => {
+      expect(
+        getBandInformation({ time: [1, 2], variable: ['pr', 'tavg'] })
+      ).toEqual({
+        time_1_pr: { time: 1, variable: 'pr' },
+        time_2_pr: { time: 2, variable: 'pr' },
+        time_1_tavg: { time: 1, variable: 'tavg' },
+        time_2_tavg: { time: 2, variable: 'tavg' },
+      })
+      expect(getBandInformation({ time: [1, 2], variable: [3, 4] })).toEqual({
+        time_1_variable_3: { time: 1, variable: 3 },
+        time_2_variable_3: { time: 2, variable: 3 },
+        time_1_variable_4: { time: 1, variable: 4 },
+        time_2_variable_4: { time: 2, variable: 4 },
+      })
+    })
+
+    it('handles mix of array selector values with non-array selector values', () => {
+      expect(
+        getBandInformation({ time: ['jan', 'feb'], variable: 'pr' })
+      ).toEqual({
+        jan: { time: 'jan', variable: 'pr' },
+        feb: { time: 'feb', variable: 'pr' },
+      })
+      expect(getBandInformation({ time: ['jan', 'feb'], variable: 3 })).toEqual(
+        {
+          jan: { time: 'jan', variable: 3 },
+          feb: { time: 'feb', variable: 3 },
+        }
+      )
+    })
+  })
+})


### PR DESCRIPTION
This fixes the issue we were seeing when trying to select down a store containing multiple bands, but also other selectors that need to be passed through. This should now include all the selectors with each band (eg elapsed_time, ids, etc)

I've tested this with the seaweed viewer and it seems to behave correctly. It's also working with OAE.