### PR TITLE
Equirectangular bugfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@carbonplan/maps",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@carbonplan/maps",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "@turf/turf": "^6.5.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -39,6 +39,7 @@ export const pointToTile = (lon, lat, z, projection, order) => {
       if (x < 0) x = x + z2
       y = Math.max(Math.min(y, z2), 0)
       tile = [x, y, z]
+      break
     default:
       return
   }


### PR DESCRIPTION
Bugfix for changes made in https://github.com/carbonplan/maps/pull/114. Now that `pointToTile()` can return early, missing `break` in `switch` block meant that empty return was always hit for equirectangular `case`.