### PR TITLE
more lenient longitude validation for region picker initialCenter

### DIFF
--- a/src/region/region-picker/index.js
+++ b/src/region/region-picker/index.js
@@ -20,10 +20,10 @@ function getInitialRadius(map, units, minRadius, maxRadius) {
 
 function isValidCoordinate(longitude, latitude) {
   return (
-    longitude !== undefined &&
-    latitude !== undefined &&
-    longitude >= -180 &&
-    longitude <= 180 &&
+    typeof longitude === 'number' &&
+    typeof latitude === 'number' &&
+    !isNaN(longitude) &&
+    !isNaN(latitude) &&
     latitude >= -90 &&
     latitude <= 90
   )


### PR DESCRIPTION
When zoomed way out, it's common for the world to wrap and features to be shown more than once on large screens. In these cases, we should allow longitudes that exceed 180 since it allows us to specify which of the duplicate features we actually want to center on. 