### PR TITLE
call setZoom before setCenter

### DIFF
--- a/src/mapbox.js
+++ b/src/mapbox.js
@@ -44,8 +44,8 @@ const Mapbox = ({
         pitchWithRotate: false,
         touchZoomRotate: true,
       })
-      if (center) map.current.setCenter(center)
       if (zoom) map.current.setZoom(zoom)
+      if (center) map.current.setCenter(center)
       map.current.touchZoomRotate.disableRotation()
       map.current.touchPitch.disable()
       map.current.on('styledata', () => {


### PR DESCRIPTION
Addresses unexpected behavior:

changing the latitude value in `setCenter()` has no effect on the map view if `setZoom()` is called after it, so the order of operations should be inverted

- `setCenter()` should ideally be called after `setZoom()`, otherwise the latitude will always be constrained by the height of the viewport.   Issue originally noted in https://github.com/mapbox/mapbox-gl-js/issues/2864