### PR TITLE
BYO map

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,24 @@
   "description": "interactive data-driven web maps",
   "main": "dst/index.js",
   "module": "dst/index.esm.js",
+  "exports": {
+    ".": {
+      "import": "./dst/index.esm.js",
+      "require": "./dst/index.js"
+    },
+    "./core": {
+      "import": "./dst/core.esm.js",
+      "require": "./dst/core.js"
+    },
+    "./mapbox.css": "./mapbox.css"
+  },
   "scripts": {
-    "build": "rimraf dst && microbundle src/index.js -o dst/index.js --no-compress --jsx React.createElement -f modern,es,cjs --jsxFragment React.Fragment",
-    "watch": "microbundle watch src/index.js -o dst/index.js --no-compress --jsx React.createElement -f modern,es,cjs --jsxFragment React.Fragment",
+    "build": "rimraf dst && npm run build:main && npm run build:core",
+    "build:main": "microbundle src/index.js -o dst/index.js --no-compress --jsx React.createElement -f modern,es,cjs --jsxFragment React.Fragment",
+    "build:core": "microbundle src/core.js -o dst/core.js --no-compress --jsx React.createElement -f modern,es,cjs --jsxFragment React.Fragment",
+    "watch": "npm run watch:main & npm run watch:core",
+    "watch:main": "microbundle watch src/index.js -o dst/index.js --no-compress --jsx React.createElement -f modern,es,cjs --jsxFragment React.Fragment",
+    "watch:core": "microbundle watch src/core.js -o dst/core.js --no-compress --jsx React.createElement -f modern,es,cjs --jsxFragment React.Fragment",
     "test": "NODE_ENV=test jest --watch",
     "test:ci": "NODE_ENV=test jest --ci --reporters='default'",
     "format": "prettier --write 'src/**/*.js'"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbonplan/maps",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "interactive data-driven web maps",
   "main": "dst/index.js",
   "module": "dst/index.esm.js",
@@ -19,6 +19,7 @@
     "carbonplan",
     "webgl",
     "mapbox",
+    "maplibre",
     "regl",
     "mapping"
   ],

--- a/src/core.js
+++ b/src/core.js
@@ -1,6 +1,5 @@
-export { default as Map } from './map'
-export { default as Mapbox } from './mapbox'
-export { useMap as useMapbox } from './map-provider'
+// no mapbox dependencies
+export { MapProvider, useMap } from './map-provider'
 export { default as RegionPicker } from './region/region-picker'
 export { useRegion } from './region/context'
 export { useRecenterRegion } from './use-recenter-region'

--- a/src/fill.js
+++ b/src/fill.js
@@ -1,10 +1,10 @@
 import { useEffect, useRef } from 'react'
-import { useMapbox } from './mapbox'
+import { useMap } from './map-provider'
 import { updatePaintProperty } from './utils'
 import { v4 as uuidv4 } from 'uuid'
 
 const Fill = ({ source, variable, color, id, maxZoom = 5, opacity = 1 }) => {
-  const { map } = useMapbox()
+  const { map } = useMap()
   const removed = useRef(false)
 
   const sourceIdRef = useRef()

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,4 @@
 export { default as Map } from './map'
-export { default as Mapbox } from './mapbox'
-export { useMapbox } from './mapbox'
 export { default as RegionPicker } from './region/region-picker'
 export { useRegion } from './region/context'
 export { useRecenterRegion } from './use-recenter-region'
@@ -11,3 +9,11 @@ export { default as Line } from './line'
 export { default as Fill } from './fill'
 export { useControls } from './use-controls'
 export { default as useRuler } from './use-ruler'
+
+// External map support
+export { MapProvider, useMap } from './map-provider'
+export { useLoadingContext } from './loading/context'
+
+// Backward compatibility aliases
+export { MapProvider as Mapbox } from './map-provider'
+export { useMap as useMapbox } from './map-provider'

--- a/src/line.js
+++ b/src/line.js
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { useMapbox } from './mapbox'
+import { useMap } from './map-provider'
 import { updatePaintProperty } from './utils'
 import { v4 as uuidv4 } from 'uuid'
 
@@ -13,7 +13,7 @@ const Line = ({
   blur = 0.4,
   width = 0.5,
 }) => {
-  const { map } = useMapbox()
+  const { map } = useMap()
   const removed = useRef(false)
 
   const sourceIdRef = useRef()

--- a/src/map-provider.js
+++ b/src/map-provider.js
@@ -1,11 +1,22 @@
 import React, { createContext, useContext } from 'react'
-import { LoadingProvider } from './loading'
+import { LoadingProvider, LoadingUpdater } from './loading'
 import { RegionProvider } from './region/context'
 import Regl from './regl'
 
 const MapContext = createContext(null)
 
-export const MapProvider = ({ map, extensions, children, style }) => {
+export const MapProvider = ({
+  map,
+  extensions,
+  children,
+  style = {},
+  /** Tracks *any* pending requests made by containing `Raster` layers */
+  setLoading,
+  /** Tracks any metadata and coordinate requests made on initialization by containing `Raster` layers */
+  setMetadataLoading,
+  /** Tracks any requests of new chunks by containing `Raster` layers */
+  setChunkLoading,
+}) => {
   if (!map) {
     throw new Error(
       '@carbonplan/maps: A map instance must be provided to MapProvider'
@@ -14,25 +25,24 @@ export const MapProvider = ({ map, extensions, children, style }) => {
 
   return (
     <MapContext.Provider value={{ map }}>
-      <LoadingProvider>
-        <RegionProvider>
-          <Regl
-            extensions={extensions}
-            style={{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              right: 0,
-              bottom: 0,
-              pointerEvents: 'none',
-              zIndex: -1,
-              ...style,
-            }}
-          >
-            {children}
-          </Regl>
-        </RegionProvider>
-      </LoadingProvider>
+      <Regl
+        extensions={extensions}
+        style={{
+          position: 'absolute',
+          pointerEvents: 'none',
+          zIndex: -1,
+          ...style,
+        }}
+      >
+        <LoadingProvider>
+          <LoadingUpdater
+            setLoading={setLoading}
+            setMetadataLoading={setMetadataLoading}
+            setChunkLoading={setChunkLoading}
+          />
+          <RegionProvider>{children}</RegionProvider>
+        </LoadingProvider>
+      </Regl>
     </MapContext.Provider>
   )
 }

--- a/src/map-provider.js
+++ b/src/map-provider.js
@@ -1,0 +1,49 @@
+import React, { createContext, useContext } from 'react'
+import { LoadingProvider } from './loading'
+import { RegionProvider } from './region/context'
+import Regl from './regl'
+
+const MapContext = createContext(null)
+
+export const MapProvider = ({ map, extensions, children, style }) => {
+  if (!map) {
+    throw new Error(
+      '@carbonplan/maps: A map instance must be provided to MapProvider'
+    )
+  }
+
+  return (
+    <MapContext.Provider value={{ map }}>
+      <LoadingProvider>
+        <RegionProvider>
+          <Regl
+            extensions={extensions}
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              pointerEvents: 'none',
+              zIndex: -1,
+              ...style,
+            }}
+          >
+            {children}
+          </Regl>
+        </RegionProvider>
+      </LoadingProvider>
+    </MapContext.Provider>
+  )
+}
+
+export const useMap = () => {
+  const context = useContext(MapContext)
+
+  if (!context) {
+    throw new Error(
+      '@carbonplan/maps: useMap must be used within a MapProvider'
+    )
+  }
+  return context
+}

--- a/src/map.js
+++ b/src/map.js
@@ -3,10 +3,22 @@ import Mapbox from './mapbox'
 import { MapProvider } from './map-provider'
 import { useMapbox } from './mapbox'
 
-const MapboxToMapProvider = ({ extensions, children }) => {
+const MapboxToMapProvider = ({
+  extensions,
+  children,
+  setLoading,
+  setMetadataLoading,
+  setChunkLoading,
+}) => {
   const { map } = useMapbox()
   return (
-    <MapProvider map={map} extensions={extensions}>
+    <MapProvider
+      map={map}
+      extensions={extensions}
+      setLoading={setLoading}
+      setMetadataLoading={setMetadataLoading}
+      setChunkLoading={setChunkLoading}
+    >
       {children}
     </MapProvider>
   )
@@ -26,6 +38,12 @@ const Map = ({
   extensions,
   glyphs,
   children,
+  /** Tracks *any* pending requests made by containing `Raster` layers */
+  setLoading,
+  /** Tracks any metadata and coordinate requests made on initialization by containing `Raster` layers */
+  setMetadataLoading,
+  /** Tracks any requests of new chunks by containing `Raster` layers */
+  setChunkLoading,
 }) => {
   return (
     <div
@@ -50,7 +68,12 @@ const Map = ({
         glyphs={glyphs}
         style={{ position: 'absolute' }}
       >
-        <MapboxToMapProvider extensions={extensions}>
+        <MapboxToMapProvider
+          extensions={extensions}
+          setLoading={setLoading}
+          setMetadataLoading={setMetadataLoading}
+          setChunkLoading={setChunkLoading}
+        >
           {children}
         </MapboxToMapProvider>
       </Mapbox>

--- a/src/map.js
+++ b/src/map.js
@@ -1,8 +1,16 @@
 import React from 'react'
 import Mapbox from './mapbox'
-import Regl from './regl'
-import { RegionProvider } from './region/context'
-import { LoadingProvider, LoadingUpdater } from './loading'
+import { MapProvider } from './map-provider'
+import { useMapbox } from './mapbox'
+
+const MapboxToMapProvider = ({ extensions, children }) => {
+  const { map } = useMapbox()
+  return (
+    <MapProvider map={map} extensions={extensions}>
+      {children}
+    </MapProvider>
+  )
+}
 
 const Map = ({
   id,
@@ -18,12 +26,6 @@ const Map = ({
   extensions,
   glyphs,
   children,
-  /** Tracks *any* pending requests made by containing `Raster` layers */
-  setLoading,
-  /** Tracks any metadata and coordinate requests made on initialization by containing `Raster` layers */
-  setMetadataLoading,
-  /** Tracks any requests of new chunks by containing `Raster` layers */
-  setChunkLoading,
 }) => {
   return (
     <div
@@ -48,23 +50,9 @@ const Map = ({
         glyphs={glyphs}
         style={{ position: 'absolute' }}
       >
-        <Regl
-          extensions={extensions}
-          style={{
-            position: 'absolute',
-            pointerEvents: 'none',
-            zIndex: -1,
-          }}
-        >
-          <LoadingProvider>
-            <LoadingUpdater
-              setLoading={setLoading}
-              setMetadataLoading={setMetadataLoading}
-              setChunkLoading={setChunkLoading}
-            />
-            <RegionProvider>{children}</RegionProvider>
-          </LoadingProvider>
-        </Regl>
+        <MapboxToMapProvider extensions={extensions}>
+          {children}
+        </MapboxToMapProvider>
       </Mapbox>
     </div>
   )

--- a/src/mapbox.js
+++ b/src/mapbox.js
@@ -7,7 +7,6 @@ import React, {
   useContext,
 } from 'react'
 import mapboxgl from 'mapbox-gl'
-import 'mapbox-gl/dist/mapbox-gl.css'
 
 export const MapboxContext = createContext(null)
 

--- a/src/mapbox.js
+++ b/src/mapbox.js
@@ -7,6 +7,7 @@ import React, {
   useContext,
 } from 'react'
 import mapboxgl from 'mapbox-gl'
+import 'mapbox-gl/dist/mapbox-gl.css'
 
 export const MapboxContext = createContext(null)
 

--- a/src/raster.js
+++ b/src/raster.js
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect, useState } from 'react'
 import { useRegl } from './regl'
-import { useMapbox } from './mapbox'
+import { useMap } from './map-provider'
 import { useControls } from './use-controls'
 import { createTiles } from './tiles'
 import { useRegion } from './region/context'
@@ -22,7 +22,7 @@ const Raster = (props) => {
     new Date().getTime()
   )
   const { regl } = useRegl()
-  const { map } = useMapbox()
+  const { map } = useMap()
   const { region } = useRegion()
   const { setLoading, clearLoading, loading, chunkLoading, metadataLoading } =
     useSetLoading()

--- a/src/region/region-picker/circle-picker/index.js
+++ b/src/region/region-picker/circle-picker/index.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { useMapbox } from '../../../mapbox'
+import { useMap } from '../../../map-provider'
 import CircleRenderer from './circle-renderer'
 
 const CirclePicker = ({
@@ -16,7 +16,7 @@ const CirclePicker = ({
   maxRadius,
   minRadius,
 }) => {
-  const { map } = useMapbox()
+  const { map } = useMap()
   const [renderer, setRenderer] = useState(null)
 
   useEffect(() => {

--- a/src/region/region-picker/circle-picker/utils.js
+++ b/src/region/region-picker/circle-picker/utils.js
@@ -1,9 +1,23 @@
 import { geoPath, geoTransform } from 'd3-geo'
-import mapboxgl from 'mapbox-gl'
+
+const normalizeLngLat = (coordinates) => {
+  if (
+    coordinates &&
+    typeof coordinates.lng === 'number' &&
+    typeof coordinates.lat === 'number'
+  ) {
+    return coordinates
+  }
+  if (Array.isArray(coordinates) && coordinates.length >= 2) {
+    return { lng: coordinates[0], lat: coordinates[1] }
+  }
+  throw new Error(
+    'Invalid coordinate format. Expected [lng, lat] or {lng, lat}'
+  )
+}
 
 export const project = (map, coordinates, options = {}) => {
-  // Convert any LngLatLike to LngLat
-  const ll = mapboxgl.LngLat.convert(coordinates)
+  const ll = normalizeLngLat(coordinates)
 
   let result = map.project(ll)
 

--- a/src/region/region-picker/index.js
+++ b/src/region/region-picker/index.js
@@ -6,7 +6,6 @@ import { v4 as uuidv4 } from 'uuid'
 
 import { useRegionContext } from '../context'
 import { useMap } from '../../map-provider'
-import mapboxgl from 'mapbox-gl'
 
 function getInitialRadius(map, units, minRadius, maxRadius) {
   const bounds = map.getBounds().toArray()
@@ -35,14 +34,15 @@ function getInitialCenter(map, center) {
     center.length === 2 &&
     isValidCoordinate(center[0], center[1])
   ) {
-    return new mapboxgl.LngLat(center[0], center[1])
+    return { lng: center[0], lat: center[1] }
   } else {
     if (center) {
       console.warn(
         `Invalid initialCenter provided: ${center}. Should be [lng, lat]. Using map center instead.`
       )
     }
-    return map.getCenter()
+    const mapCenter = map.getCenter()
+    return { lng: mapCenter.lng, lat: mapCenter.lat }
   }
 }
 

--- a/src/region/region-picker/index.js
+++ b/src/region/region-picker/index.js
@@ -5,7 +5,7 @@ import { distance } from '@turf/turf'
 import { v4 as uuidv4 } from 'uuid'
 
 import { useRegionContext } from '../context'
-import { useMapbox } from '../../mapbox'
+import { useMap } from '../../map-provider'
 import mapboxgl from 'mapbox-gl'
 
 function getInitialRadius(map, units, minRadius, maxRadius) {
@@ -59,7 +59,7 @@ function RegionPicker({
   minRadius,
   maxRadius,
 }) {
-  const { map } = useMapbox()
+  const { map } = useMap()
   const id = useRef(uuidv4())
 
   const initialCenter = useRef(getInitialCenter(map, initialCenterProp))

--- a/src/use-controls.js
+++ b/src/use-controls.js
@@ -1,9 +1,9 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import { flushSync } from 'react-dom'
-import { useMapbox } from './mapbox'
+import { useMap } from './map-provider'
 
 export const useControls = () => {
-  const { map } = useMapbox()
+  const { map } = useMap()
   const [zoom, setZoom] = useState(map.getZoom())
   const [center, setCenter] = useState(map.getCenter())
 

--- a/src/use-recenter-region.js
+++ b/src/use-recenter-region.js
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react'
 
 import { useRegion } from './region/context'
-import { useMapbox } from './mapbox'
+import { useMap } from './map-provider'
 
 export const useRecenterRegion = () => {
   const [value, setValue] = useState({ recenterRegion: () => {} })
-  const { map } = useMapbox()
+  const { map } = useMap()
   const { region } = useRegion()
 
   const center = region?.properties?.center

--- a/src/use-ruler.js
+++ b/src/use-ruler.js
@@ -4,7 +4,7 @@ import { axisBottom, axisLeft } from 'd3-axis'
 import { scaleOrdinal } from 'd3-scale'
 import { select } from 'd3-selection'
 
-import { useMapbox } from './mapbox'
+import { useMap } from './map-provider'
 
 const TICK_SEPARATION = 150 // target distance between ticks
 const TICK_SIZE = 6 // tick length
@@ -16,7 +16,7 @@ function useRuler({
   fontFamily,
   gridColor,
 }) {
-  const { map } = useMapbox()
+  const { map } = useMap()
 
   useEffect(() => {
     if (!showAxes && !showGrid) {


### PR DESCRIPTION
This PR sets the groundwork for being able to pass in a map instance instead of `@carbonplan/maps` provided mapbox. This will allow integration of the library into a wider variety of applications.

Currently, this has split the bundling into two main locations, the backwards compatible imports from `@carbonplan/maps` and a new `@carbonplan/maps/core` import path that excludes all mapbox references to avoid bundling mapbox in apps that don't need it. When using `/core` imports, all components should be imported from `/core`, mixing causes react context errors. 

I did some initial exploration of a custom rollup configuration that attempted to simplify this import scheme with better treeshaking/sideEffect handling, but I so far have not been successful with getting it working. So for now this PR is sticking with the duplicative `/core` microbundle approach. 

### still TODO:
- [ ] README updates describing bundling pattern and documenting `<MapProvider>`
- [ ] Testing with a wider variety of mapping versions (latest maplibre works, but does mapbox?)
- [ ] Add map reference validation/warnings (based on above testing)
- [ ] Also add regl <> map order customization (ie zarr above vs below main map instance) via a prop that modifies zIndex (this is already possible with the style prop, but pretty buried and unintuitive) 


